### PR TITLE
feat: Standardize Dockerfile for roadmap-service service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use a lightweight base image with Java 21 JRE
+FROM bellsoft/liberica-runtime-container:jre-21-slim-musl
+
+# Set the working directory inside the container
+WORKDIR /application
+
+# Copy the Jar file
+COPY target/*-SNAPSHOT.jar app.jar
+
+# create a non-root user (Alpine / musl)
+RUN addgroup -S roadmap && adduser -S -G roadmap roadmap
+
+# Switch to non-root user
+USER roadmap
+
+# Expose the port that the application will run on
+EXPOSE 8110
+
+# Set JVM options for optimal container performance
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/./urandom"
+
+# Run the application
+CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
- Updated to use Liberica JRE 21 slim base image
- Optimized JVM settings for container environment
- Security: Switch to non-root user (roadmap)
- Expose port 8110 for roadmap-service service
- Consistent structure across all microservices
- Added backup of previous Dockerfile