### PR TITLE
Feat: Kafka Integration VER-152

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ build/
 ### VS Code ###
 .vscode/
 .env
+.claude/

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,19 @@
 		<java.version>21</java.version>
 		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/karangwaajika/versapath-events</url>
+        </repository>
+    </repositories>
 	<dependencies>
+        <dependency>
+            <groupId>org.common</groupId>
+            <artifactId>versapath-events</artifactId>
+            <version>2.2</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>

--- a/src/main/java/com/capstone/config/KafkaConfig.java
+++ b/src/main/java/com/capstone/config/KafkaConfig.java
@@ -1,0 +1,14 @@
+package com.capstone.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaConfig {
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> producerFactory) {
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/src/main/java/com/capstone/dto/response/ApiResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/ApiResponseDto.java
@@ -1,0 +1,78 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponseDto<T> {
+    private boolean success;
+    private String message;
+    private T data;
+    private List<String> errors;
+
+    // Static factory methods for success responses
+    public static <T> ApiResponseDto<T> success(T data) {
+        return ApiResponseDto.<T>builder()
+                .success(true)
+                .message("Operation completed successfully")
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponseDto<T> success(T data, String message) {
+        return ApiResponseDto.<T>builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponseDto<T> success(String message) {
+        return ApiResponseDto.<T>builder()
+                .success(true)
+                .message(message)
+                .build();
+    }
+
+    // Static factory methods for error responses
+    public static <T> ApiResponseDto<T> error(List<String> errors) {
+        return ApiResponseDto.<T>builder()
+                .success(false)
+                .message("Operation failed")
+                .errors(errors)
+                .build();
+    }
+
+    public static <T> ApiResponseDto<T> error(String error) {
+        return ApiResponseDto.<T>builder()
+                .success(false)
+                .message("Operation failed")
+                .errors(List.of(error))
+                .build();
+    }
+
+    public static <T> ApiResponseDto<T> error(List<String> errors, String message) {
+        return ApiResponseDto.<T>builder()
+                .success(false)
+                .message(message)
+                .errors(errors)
+                .build();
+    }
+
+    public static <T> ApiResponseDto<T> error(String error, String message) {
+        return ApiResponseDto.<T>builder()
+                .success(false)
+                .message(message)
+                .errors(List.of(error))
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/exception/DuplicateUserException.java
+++ b/src/main/java/com/capstone/exception/DuplicateUserException.java
@@ -1,0 +1,11 @@
+package com.capstone.exception;
+
+public class DuplicateUserException extends RuntimeException {
+    public DuplicateUserException(String message) {
+        super(message);
+    }
+
+    public DuplicateUserException(String field, String value) {
+        super("User already exists with " + field + ": " + value);
+    }
+}

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -1,0 +1,98 @@
+package com.capstone.exception;
+
+import com.capstone.dto.response.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@RestControllerAdvice
+@Slf4j
+@Hidden
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleUserNotFoundException(UserNotFoundException ex) {
+        log.error("User not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseDto.error(ex.getMessage(), "User not found"));
+    }
+
+    @ExceptionHandler(DuplicateUserException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleDuplicateUserException(DuplicateUserException ex) {
+        log.error("Duplicate user error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(ex.getMessage(), "Duplicate user"));
+    }
+
+    @ExceptionHandler(UserProcessingException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleUserProcessingException(UserProcessingException ex) {
+        log.error("User processing error: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponseDto.error(ex.getMessage(), "User processing failed"));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        log.error("Data integrity violation: {}", ex.getMessage());
+
+        String message = "Data integrity violation";
+        String rootCause = ex.getRootCause() != null ? ex.getRootCause().getMessage() : ex.getMessage();
+
+        // Check for specific constraint violations
+        if (rootCause != null) {
+            if (rootCause.contains("user_id")) {
+                message = "User with this ID already exists";
+            } else if (rootCause.contains("email")) {
+                message = "User with this email already exists";
+            } else if (rootCause.contains("username")) {
+                message = "User with this username already exists";
+            }
+        }
+
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(message, "Data constraint violation"));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+        log.error("Validation error: {}", ex.getMessage());
+
+        List<String> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponseDto.error(errors, "Validation failed"));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleConstraintViolationException(ConstraintViolationException ex) {
+        log.error("Constraint violation: {}", ex.getMessage());
+
+        List<String> errors = ex.getConstraintViolations()
+                .stream()
+                .map(ConstraintViolation::getMessage)
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponseDto.error(errors, "Validation constraint violation"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleGenericException(Exception ex) {
+        log.error("Unexpected error occurred: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponseDto.error("An unexpected error occurred", "Internal server error"));
+    }
+}

--- a/src/main/java/com/capstone/exception/UserNotFoundException.java
+++ b/src/main/java/com/capstone/exception/UserNotFoundException.java
@@ -1,0 +1,16 @@
+package com.capstone.exception;
+
+import java.util.UUID;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+    public UserNotFoundException(UUID userId) {
+        super("User not found with ID: " + userId);
+    }
+
+    public UserNotFoundException(String field, String value) {
+        super("User not found with " + field + ": " + value);
+    }
+}

--- a/src/main/java/com/capstone/exception/UserProcessingException.java
+++ b/src/main/java/com/capstone/exception/UserProcessingException.java
@@ -1,0 +1,14 @@
+package com.capstone.exception;
+
+public class UserProcessingException extends RuntimeException {
+    public UserProcessingException(String message) {
+        super(message);
+    }
+    public UserProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UserProcessingException(Throwable cause) {
+        super("Failed to process user event", cause);
+    }
+}

--- a/src/main/java/com/capstone/mapper/UserEventMapper.java
+++ b/src/main/java/com/capstone/mapper/UserEventMapper.java
@@ -1,0 +1,23 @@
+package com.capstone.mapper;
+
+import com.capstone.model.UserSnapshot;
+import org.common.event.ProduceUserEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface UserEventMapper {
+
+    @Mapping(source = "versapathUserId", target = "userId")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    UserSnapshot toUserSnapshot(ProduceUserEvent event);
+
+    @Mapping(target = "userId", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    void updateUserSnapshot(ProduceUserEvent event, @MappingTarget UserSnapshot userSnapshot);
+}

--- a/src/main/java/com/capstone/messaging/KafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/KafkaConsumer.java
@@ -1,0 +1,128 @@
+package com.capstone.messaging;
+
+import com.capstone.exception.UserProcessingException;
+import com.capstone.model.UserSnapshot;
+import com.capstone.service.UserSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.ProduceUserEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class KafkaConsumer {
+
+    private final UserSnapshotService userSnapshotService;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${app.kafka.dlt-topic:user.create.dlt}")
+    private String dltTopic;
+
+    @KafkaListener(topics = "user.create")
+    @Retryable(
+            retryFor = {UserProcessingException.class, Exception.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listen(
+            @Payload ProduceUserEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received user.create event from topic: {}, partition: {}, offset: {}, userId: {}",
+                topic, partition, offset, event.getVersapathUserId());
+
+        try {
+            // Validate event
+            validateUserEvent(event);
+
+            // Process the user event
+            UserSnapshot processedUser = userSnapshotService.processUserEvent(event);
+
+            log.info("Successfully processed user event for userId: {}, internal ID: {}",
+                    event.getVersapathUserId(), processedUser.getId());
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (UserProcessingException e) {
+            log.error("Failed to process user event for userId: {}. Error: {}",
+                    event.getVersapathUserId(), e.getMessage(), e);
+            handleProcessingFailure(event, e, acknowledgment);
+
+        } catch (Exception e) {
+            log.error("Unexpected error processing user event for userId: {}. Error: {}",
+                    event.getVersapathUserId(), e.getMessage(), e);
+            handleProcessingFailure(event, e, acknowledgment);
+        }
+    }
+
+    private void validateUserEvent(ProduceUserEvent event) {
+        log.debug("Validating user event: {}", event);
+
+        if (event == null) {
+            throw new UserProcessingException("User event cannot be null");
+        }
+
+        if (event.getVersapathUserId() == null) {
+            throw new UserProcessingException("User event must contain a valid userId");
+        }
+
+        if (event.getEmail() == null || event.getEmail().trim().isEmpty()) {
+            throw new UserProcessingException("User event must contain a valid email");
+        }
+
+        if (event.getFirstName() == null || event.getFirstName().trim().isEmpty()) {
+            throw new UserProcessingException("User event must contain a valid first name");
+        }
+
+        if (event.getLastName() == null || event.getLastName().trim().isEmpty()) {
+            throw new UserProcessingException("User event must contain a valid last name");
+        }
+
+        if (event.getUsername() == null || event.getUsername().trim().isEmpty()) {
+            throw new UserProcessingException("User event must contain a valid username");
+        }
+
+        log.debug("User event validation successful for userId: {}", event.getVersapathUserId());
+    }
+
+    private void handleProcessingFailure(ProduceUserEvent event, Exception e, Acknowledgment acknowledgment) {
+        String userId = event.getVersapathUserId().toString();
+
+        log.error("Processing failed for user event with userId: {}. Sending to DLT topic: {}",
+                userId, dltTopic);
+
+        try {
+            // Send to Dead Letter Topic for manual review/reprocessing
+            kafkaTemplate.send(dltTopic, userId, event)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            log.info("Successfully sent failed event to DLT for userId: {}", userId);
+                        } else {
+                            log.error("Failed to send event to DLT for userId: {}", userId, ex);
+                        }
+                    });
+
+            // Acknowledge the original message to prevent infinite retries
+            acknowledgment.acknowledge();
+
+        } catch (Exception dltException) {
+            log.error("Critical: Failed to send message to DLT for userId: {}. Message will be retried by Kafka",
+                    userId, dltException);
+            // Don't acknowledge - let Kafka handle the retry
+        }
+    }
+}

--- a/src/main/java/com/capstone/model/UserSnapshot.java
+++ b/src/main/java/com/capstone/model/UserSnapshot.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -22,11 +23,20 @@ public class UserSnapshot {
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
+    @NotNull(message = "User ID is required")
+    @Column(nullable = false, unique = true, updatable = false, name = "user_id")
+    private UUID userId;
+
     @Email(message = "Email should be valid")
     @NotBlank(message = "Email is required")
     @Size(max = 255, message = "Email must not exceed 255 characters")
     @Column(nullable = false, unique = true)
     private String email;
+
+    @NotBlank(message = "Username is required")
+    @Size(max = 100, message = "Username must not exceed 100 characters")
+    @Column(nullable = false, unique = true)
+    private String username;
 
     @NotBlank(message = "First name is required")
     @Size(max = 255, message = "First name must not exceed 255 characters")
@@ -37,6 +47,23 @@ public class UserSnapshot {
     @Size(max = 255, message = "Last name must not exceed 255 characters")
     @Column(name = "last_name", nullable = false)
     private String lastName;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 
     public String getFullName() {
         return firstName + " " + lastName;

--- a/src/main/java/com/capstone/repository/UserSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/UserSnapshotRepository.java
@@ -4,8 +4,11 @@ import com.capstone.model.UserSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface UserSnapshotRepository extends JpaRepository<UserSnapshot, UUID> {
+    Optional<UserSnapshot> findByUserId(UUID userId);
+    boolean existsByUserId(UUID userId);
 }

--- a/src/main/java/com/capstone/service/UserSnapshotService.java
+++ b/src/main/java/com/capstone/service/UserSnapshotService.java
@@ -1,0 +1,25 @@
+package com.capstone.service;
+
+import com.capstone.model.UserSnapshot;
+import org.common.event.ProduceUserEvent;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserSnapshotService {
+
+    /**
+     * Process user event from Kafka - creates new user or updates existing one
+     * @param event the user event from Kafka
+     * @return the processed UserSnapshot
+     */
+    UserSnapshot processUserEvent(ProduceUserEvent event);
+
+    UserSnapshot createUser(ProduceUserEvent event);
+
+    UserSnapshot updateUser(UserSnapshot existingUser, ProduceUserEvent event);
+
+    Optional<UserSnapshot> findByUserId(UUID userId);
+
+    boolean existsByUserId(UUID userId);
+}

--- a/src/main/java/com/capstone/service/impl/UserSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/UserSnapshotServiceImpl.java
@@ -1,0 +1,99 @@
+package com.capstone.service.impl;
+
+import com.capstone.exception.UserProcessingException;
+import com.capstone.mapper.UserEventMapper;
+import com.capstone.model.UserSnapshot;
+import com.capstone.repository.UserSnapshotRepository;
+import com.capstone.service.UserSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.ProduceUserEvent;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class UserSnapshotServiceImpl implements UserSnapshotService {
+
+    private final UserSnapshotRepository userSnapshotRepository;
+    private final UserEventMapper userEventMapper;
+
+    @Override
+    public UserSnapshot processUserEvent(ProduceUserEvent event) {
+        log.info("Processing user event for userId: {}", event.getVersapathUserId());
+
+        try {
+            Optional<UserSnapshot> existingUser = findByUserId(event.getVersapathUserId());
+
+            if (existingUser.isPresent()) {
+                log.info("User exists, updating user with ID: {}", event.getVersapathUserId());
+                return updateUser(existingUser.get(), event);
+            } else {
+                log.info("User does not exist, creating new user with ID: {}", event.getVersapathUserId());
+                return createUser(event);
+            }
+
+        } catch (Exception e) {
+            log.error("Error processing user event for userId: {}", event.getVersapathUserId(), e);
+            throw new UserProcessingException("Failed to process user event", e);
+        }
+    }
+
+    @Override
+    public UserSnapshot createUser(ProduceUserEvent event) {
+        log.debug("Creating new user from event: {}", event);
+
+        try {
+            UserSnapshot newUser = userEventMapper.toUserSnapshot(event);
+            UserSnapshot savedUser = userSnapshotRepository.save(newUser);
+            log.info("Successfully created user with ID: {}", savedUser.getUserId());
+            return savedUser;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when creating user with ID: {}", event.getVersapathUserId(), e);
+            throw new UserProcessingException("User creation failed due to data constraint violation", e);
+        } catch (Exception e) {
+            log.error("Unexpected error creating user with ID: {}", event.getVersapathUserId(), e);
+            throw new UserProcessingException("Failed to create user", e);
+        }
+    }
+
+    @Override
+    public UserSnapshot updateUser(UserSnapshot existingUser, ProduceUserEvent event) {
+        log.debug("Updating existing user {} with event data: {}", existingUser.getUserId(), event);
+
+        try {
+            userEventMapper.updateUserSnapshot(event, existingUser);
+            UserSnapshot updatedUser = userSnapshotRepository.save(existingUser);
+            log.info("Successfully updated user with ID: {}", updatedUser.getUserId());
+            return updatedUser;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when updating user with ID: {}", existingUser.getUserId(), e);
+            throw new UserProcessingException("User update failed due to data constraint violation", e);
+        } catch (Exception e) {
+            log.error("Unexpected error updating user with ID: {}", existingUser.getUserId(), e);
+            throw new UserProcessingException("Failed to update user", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<UserSnapshot> findByUserId(UUID userId) {
+        log.debug("Finding user by userId: {}", userId);
+        return userSnapshotRepository.findByUserId(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByUserId(UUID userId) {
+        log.debug("Checking if user exists by userId: {}", userId);
+        return userSnapshotRepository.existsByUserId(userId);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,42 @@ spring:
     name: ${SPRING_APPLICATION_NAME}
   config:
     import: optional:configserver:${CONFIG_SERVER_URL}
+
+  kafka:
+    bootstrap-servers: pkc-619z3.us-east1.gcp.confluent.cloud:9092
+    properties:
+      sasl.mechanism: PLAIN
+      security.protocol: SASL_SSL
+      sasl.jaas.config: >
+        org.apache.kafka.common.security.plain.PlainLoginModule required                                                                          
+        username='${KAFKA_API_KEY}'                                                                                                               
+        password='${KAFKA_API_SECRET}';
+      session.timeout.ms: 45000
+
+    consumer:
+      group-id: roadmap-service-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      enable-auto-commit: false
+      max-poll-records: 50
+      properties:
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.value.default.type: org.common.event.ProduceUserEvent
+        spring.json.trusted.packages: "*"
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      retries: 3
+      properties:
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 5
+
+    listener:
+      ack-mode: manual_immediate
+
+app:
+  kafka:
+    dlt-topic: user.create.dlt


### PR DESCRIPTION
# 🚀   Pull Request: Integration of Kafka into the Roadmap Service
### 🎫   Jira Ticket
[:link:  SPRINT-2/VER-20: Consuming User events and persist them into the database](https://amali-tech.atlassian.net/browse/VER-152)
---
## :white_check_mark:  Summary
This PR provides the integration of kafka events  such as `user.create`  in Roadmap service to consume the event and persist the information into the database.
---
## :pushpin:  Features  Added
- [x] `KafkaConsumer` to listen and consume events
- [x] Service logic to persist the user information in the database
- [x] `GlobalExceptionHandler` for handling exceptions across the application
- [x] `ApiResponseDto` for structured api responses, used currently in the GlobalExceptionHandler
- [x] Proper mapping using `mapstruct` for performance optimization 
---
## 🚧  Next Task
- Integrating `skill-taxonomy` events into `roadmap-service`