### PR TITLE
Feat: Kafka Integration VER-152

### DIFF
--- a/src/main/java/com/capstone/dto/response/ApiResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/ApiResponseDto.java
@@ -43,23 +43,6 @@ public class ApiResponseDto<T> {
                 .build();
     }
 
-    // Static factory methods for error responses
-    public static <T> ApiResponseDto<T> error(List<String> errors) {
-        return ApiResponseDto.<T>builder()
-                .success(false)
-                .message("Operation failed")
-                .errors(errors)
-                .build();
-    }
-
-    public static <T> ApiResponseDto<T> error(String error) {
-        return ApiResponseDto.<T>builder()
-                .success(false)
-                .message("Operation failed")
-                .errors(List.of(error))
-                .build();
-    }
-
     public static <T> ApiResponseDto<T> error(List<String> errors, String message) {
         return ApiResponseDto.<T>builder()
                 .success(false)

--- a/src/main/java/com/capstone/exception/DuplicateSkillAtomException.java
+++ b/src/main/java/com/capstone/exception/DuplicateSkillAtomException.java
@@ -1,0 +1,11 @@
+package com.capstone.exception;
+
+public class DuplicateSkillAtomException extends RuntimeException{
+    public DuplicateSkillAtomException(String message) {
+        super(message);
+    }
+
+    public DuplicateSkillAtomException(String field, String value) {
+        super("Skill atom already exists with " + field + ": " + value);
+    }
+}

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -95,4 +95,27 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponseDto.error("An unexpected error occurred", "Internal server error"));
     }
+
+    //SkillAtom Exceptions
+
+    @ExceptionHandler(SkillAtomNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleSkillAtomNotFoundException(SkillAtomNotFoundException ex) {
+        log.error("Skill atom not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseDto.error(ex.getMessage(), "Skill atom not found"));
+    }
+
+    @ExceptionHandler(DuplicateSkillAtomException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleDuplicateSkillAtomException(DuplicateSkillAtomException ex) {
+        log.error("Duplicate skill atom error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(ex.getMessage(), "Duplicate skill atom"));
+    }
+
+    @ExceptionHandler(SkillAtomProcessingException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleSkillAtomProcessingException(SkillAtomProcessingException ex) {
+        log.error("Skill atom processing error: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponseDto.error(ex.getMessage(), "Skill atom processing failed"));
+    }
 }

--- a/src/main/java/com/capstone/exception/SkillAtomNotFoundException.java
+++ b/src/main/java/com/capstone/exception/SkillAtomNotFoundException.java
@@ -1,0 +1,16 @@
+package com.capstone.exception;
+
+import java.util.UUID;
+
+public class SkillAtomNotFoundException extends RuntimeException {
+    public SkillAtomNotFoundException(String message) {
+        super(message);
+    }
+
+    public SkillAtomNotFoundException(UUID skillAtomId) {
+        super("Skill atom not found with ID: " + skillAtomId);
+    }
+    public SkillAtomNotFoundException(String field, String value) {
+        super("Skill atom not found with " + field + ": " + value);
+    }
+}

--- a/src/main/java/com/capstone/exception/SkillAtomProcessingException.java
+++ b/src/main/java/com/capstone/exception/SkillAtomProcessingException.java
@@ -1,0 +1,14 @@
+package com.capstone.exception;
+
+public class SkillAtomProcessingException extends RuntimeException {
+    public SkillAtomProcessingException(String message) {
+        super(message);
+    }
+    public SkillAtomProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SkillAtomProcessingException(Throwable cause) {
+        super("Failed to process skill atom event", cause);
+    }
+}

--- a/src/main/java/com/capstone/mapper/SkillAtomEventMapper.java
+++ b/src/main/java/com/capstone/mapper/SkillAtomEventMapper.java
@@ -1,0 +1,25 @@
+package com.capstone.mapper;
+
+import com.capstone.model.SkillAtomSnapshot;
+import org.common.event.SkillAtomEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface SkillAtomEventMapper {
+
+    @Mapping(source = "id", target = "skillAtomId")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "learnerAtomProgresses", ignore = true)
+    SkillAtomSnapshot toSkillAtomSnapshot(SkillAtomEvent event);
+
+    @Mapping(target = "skillAtomId", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "learnerAtomProgresses", ignore = true)
+    void updateSkillAtomSnapshot(SkillAtomEvent event, @MappingTarget SkillAtomSnapshot skillAtomSnapshot);
+}

--- a/src/main/java/com/capstone/messaging/AtomKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/AtomKafkaConsumer.java
@@ -1,0 +1,113 @@
+package com.capstone.messaging;
+
+import com.capstone.exception.SkillAtomProcessingException;
+import com.capstone.model.SkillAtomSnapshot;
+import com.capstone.service.SkillAtomSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.SkillAtomEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AtomKafkaConsumer {
+    private final SkillAtomSnapshotService skillAtomSnapshotService;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${app.kafka.atom-dlt-topic:atom.create.dlt}")
+    private String atomDltTopic;
+
+    @KafkaListener(topics = "atom.create")
+    @Retryable(
+            retryFor = {SkillAtomProcessingException.class, Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenAtomCreate(
+            @Payload SkillAtomEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received atom.create event from topic: {}, partition: {}, offset: {}, atomId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate event
+            validateSkillAtomEvent(event);
+
+            // Process the skill atom event
+            SkillAtomSnapshot processedAtom = skillAtomSnapshotService.processSkillAtomEvent(event);
+
+            log.info("Successfully processed skill atom event for atomId: {}, internal ID: {}",
+                    event.getId(), processedAtom.getId());
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (SkillAtomProcessingException e) {
+            log.error("Failed to process skill atom event for atomId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (Exception e) {
+            log.error("Unexpected error processing skill atom event for atomId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+        }
+    }
+
+    private void validateSkillAtomEvent(SkillAtomEvent event) {
+        log.debug("Validating skill atom event: {}", event);
+
+        if (event == null) {
+            throw new SkillAtomProcessingException("Skill atom event cannot be null");
+        }
+
+        if (event.getId() == null) {
+            throw new SkillAtomProcessingException("Skill atom event must contain a valid ID");
+        }
+
+        if (event.getName() == null || event.getName().trim().isEmpty()) {
+            throw new SkillAtomProcessingException("Skill atom event must contain a valid name");
+        }
+
+        log.debug("Skill atom event validation successful for atomId: {}", event.getId());
+    }
+
+    private void handleProcessingFailure(SkillAtomEvent event, Acknowledgment acknowledgment) {
+        String atomId = event.getId().toString();
+
+        log.error("Processing failed for skill atom event with atomId: {}. Sending to DLT topic: {}",
+                atomId, atomDltTopic);
+
+        try {
+            // Send to Dead Letter Topic for manual review/reprocessing
+            kafkaTemplate.send(atomDltTopic, atomId, event)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            log.info("Successfully sent failed skill atom event to DLT for atomId: {}", atomId);
+                        } else {
+                            log.error("Failed to send skill atom event to DLT for atomId: {}", atomId, ex);
+                        }
+                    });
+
+            // Acknowledge the original message to prevent infinite retries
+            acknowledgment.acknowledge();
+
+        } catch (Exception dltException) {
+            log.error("Critical: Failed to send skill atom message to DLT for atomId: {}. Message will be retried by Kafka",
+                    atomId, dltException);
+        }
+    }
+}

--- a/src/main/java/com/capstone/messaging/UserKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/UserKafkaConsumer.java
@@ -31,7 +31,6 @@ public class KafkaConsumer {
     @KafkaListener(topics = "user.create")
     @Retryable(
             retryFor = {UserProcessingException.class, Exception.class},
-            maxAttempts = 3,
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
     public void listen(
@@ -60,12 +59,12 @@ public class KafkaConsumer {
         } catch (UserProcessingException e) {
             log.error("Failed to process user event for userId: {}. Error: {}",
                     event.getVersapathUserId(), e.getMessage(), e);
-            handleProcessingFailure(event, e, acknowledgment);
+            handleProcessingFailure(event, acknowledgment);
 
         } catch (Exception e) {
             log.error("Unexpected error processing user event for userId: {}. Error: {}",
                     event.getVersapathUserId(), e.getMessage(), e);
-            handleProcessingFailure(event, e, acknowledgment);
+            handleProcessingFailure(event, acknowledgment);
         }
     }
 
@@ -99,7 +98,7 @@ public class KafkaConsumer {
         log.debug("User event validation successful for userId: {}", event.getVersapathUserId());
     }
 
-    private void handleProcessingFailure(ProduceUserEvent event, Exception e, Acknowledgment acknowledgment) {
+    private void handleProcessingFailure(ProduceUserEvent event, Acknowledgment acknowledgment) {
         String userId = event.getVersapathUserId().toString();
 
         log.error("Processing failed for user event with userId: {}. Sending to DLT topic: {}",
@@ -122,7 +121,6 @@ public class KafkaConsumer {
         } catch (Exception dltException) {
             log.error("Critical: Failed to send message to DLT for userId: {}. Message will be retried by Kafka",
                     userId, dltException);
-            // Don't acknowledge - let Kafka handle the retry
         }
     }
 }

--- a/src/main/java/com/capstone/messaging/UserKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/UserKafkaConsumer.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class KafkaConsumer {
+public class UserKafkaConsumer {
 
     private final UserSnapshotService userSnapshotService;
     private final KafkaTemplate<String, Object> kafkaTemplate;
@@ -33,7 +33,7 @@ public class KafkaConsumer {
             retryFor = {UserProcessingException.class, Exception.class},
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
-    public void listen(
+    public void listenUserCreate(
             @Payload ProduceUserEvent event,
             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
             @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,

--- a/src/main/java/com/capstone/model/SkillAtomSnapshot.java
+++ b/src/main/java/com/capstone/model/SkillAtomSnapshot.java
@@ -2,10 +2,12 @@ package com.capstone.model;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -24,15 +26,42 @@ public class SkillAtomSnapshot {
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
-    @NotBlank(message = "Skill name is required")
+    @NotNull(message = "Skill atom ID is required")
+    @Column(nullable = false, unique = true, updatable = false, name = "skill_atom_id")
+    private UUID skillAtomId;
+
+    @NotBlank(message = "Skill atom name is required")
     @Size(max = 255, message = "Skill name must not exceed 255 characters")
-    @Column(name = "skill_name", nullable = false, length = 255)
-    private String skillName;
+    @Column(name = "skill_atom_name", nullable = false)
+    private String name;
 
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
+    @Column(name = "moodle_module_id")
+    private Integer moodleModuleId;
+
+    @Column(name = "moodle_page_id")
+    private Integer moodlePageId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
     @OneToMany(mappedBy = "skillAtom", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<LearnerAtomProgress> learnerAtomProgresses = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/capstone/repository/SkillAtomSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/SkillAtomSnapshotRepository.java
@@ -5,8 +5,11 @@ import com.capstone.model.SkillAtomSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface SkillAtomSnapshotRepository extends JpaRepository<SkillAtomSnapshot, UUID> {
+    Optional<SkillAtomSnapshot> findBySkillAtomId(UUID skillAtomId);
+    boolean existsBySkillAtomId(UUID skillAtomId);
 }

--- a/src/main/java/com/capstone/service/SkillAtomSnapshotService.java
+++ b/src/main/java/com/capstone/service/SkillAtomSnapshotService.java
@@ -1,0 +1,15 @@
+package com.capstone.service;
+
+import com.capstone.model.SkillAtomSnapshot;
+import org.common.event.SkillAtomEvent;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SkillAtomSnapshotService {
+    SkillAtomSnapshot processSkillAtomEvent(SkillAtomEvent event);
+    SkillAtomSnapshot createSkillAtom(SkillAtomEvent event);
+    SkillAtomSnapshot updateSkillAtom(SkillAtomSnapshot existingSkillAtom, SkillAtomEvent event);
+    Optional<SkillAtomSnapshot> findBySkillAtomId(UUID skillAtomId);
+    boolean existsBySkillAtomId(UUID skillAtomId);
+}

--- a/src/main/java/com/capstone/service/impl/SkillAtomSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/SkillAtomSnapshotServiceImpl.java
@@ -1,0 +1,99 @@
+package com.capstone.service.impl;
+
+import com.capstone.exception.SkillAtomProcessingException;
+import com.capstone.mapper.SkillAtomEventMapper;
+import com.capstone.model.SkillAtomSnapshot;
+import com.capstone.repository.SkillAtomSnapshotRepository;
+import com.capstone.service.SkillAtomSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.SkillAtomEvent;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class SkillAtomSnapshotServiceImpl implements SkillAtomSnapshotService {
+
+    private final SkillAtomSnapshotRepository skillAtomSnapshotRepository;
+    private final SkillAtomEventMapper skillAtomEventMapper;
+
+    @Override
+    public SkillAtomSnapshot processSkillAtomEvent(SkillAtomEvent event) {
+        log.info("Processing skill atom event for skillAtomId: {}", event.getId());
+
+        try {
+            Optional<SkillAtomSnapshot> existingSkillAtom = findBySkillAtomId(event.getId());
+
+            if (existingSkillAtom.isPresent()) {
+                log.info("Skill atom exists, updating skill atom with ID: {}", event.getId());
+                return updateSkillAtom(existingSkillAtom.get(), event);
+            } else {
+                log.info("Skill atom does not exist, creating new skill atom with ID: {}", event.getId());
+                return createSkillAtom(event);
+            }
+
+        } catch (Exception e) {
+            log.error("Error processing skill atom event for skillAtomId: {}", event.getId(), e);
+            throw new SkillAtomProcessingException("Failed to process skill atom event", e);
+        }
+    }
+
+    @Override
+    public SkillAtomSnapshot createSkillAtom(SkillAtomEvent event) {
+        log.debug("Creating new skill atom from event: {}", event);
+
+        try {
+            SkillAtomSnapshot newSkillAtom = skillAtomEventMapper.toSkillAtomSnapshot(event);
+            SkillAtomSnapshot savedSkillAtom = skillAtomSnapshotRepository.save(newSkillAtom);
+            log.info("Successfully created skill atom with ID: {}", savedSkillAtom.getSkillAtomId());
+            return savedSkillAtom;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when creating skill atom with ID: {}", event.getId(), e);
+            throw new SkillAtomProcessingException("Skill atom creation failed due to data constraint violation", e);
+        } catch (Exception e) {
+            log.error("Unexpected error creating skill atom with ID: {}", event.getId(), e);
+            throw new SkillAtomProcessingException("Failed to create skill atom", e);
+        }
+    }
+
+    @Override
+    public SkillAtomSnapshot updateSkillAtom(SkillAtomSnapshot existingSkillAtom, SkillAtomEvent event) {
+        log.debug("Updating existing skill atom {} with event data: {}", existingSkillAtom.getSkillAtomId(), event);
+
+        try {
+            skillAtomEventMapper.updateSkillAtomSnapshot(event, existingSkillAtom);
+            SkillAtomSnapshot updatedSkillAtom = skillAtomSnapshotRepository.save(existingSkillAtom);
+            log.info("Successfully updated skill atom with ID: {}", updatedSkillAtom.getSkillAtomId());
+            return updatedSkillAtom;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when updating skill atom with ID: {}", existingSkillAtom.getSkillAtomId(), e);
+            throw new SkillAtomProcessingException("Skill atom update failed due to data constraint violation", e);
+        } catch (Exception e) {
+            log.error("Unexpected error updating skill atom with ID: {}", existingSkillAtom.getSkillAtomId(), e);
+            throw new SkillAtomProcessingException("Failed to update skill atom", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<SkillAtomSnapshot> findBySkillAtomId(UUID skillAtomId) {
+        log.debug("Finding skill atom by skillAtomId: {}", skillAtomId);
+        return skillAtomSnapshotRepository.findBySkillAtomId(skillAtomId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsBySkillAtomId(UUID skillAtomId) {
+        log.debug("Checking if skill atom exists by skillAtomId: {}", skillAtomId);
+        return skillAtomSnapshotRepository.existsBySkillAtomId(skillAtomId);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,8 +27,8 @@ spring:
       max-poll-records: 50
       properties:
         spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-        spring.json.value.default.type: org.common.event.ProduceUserEvent
         spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: true
 
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
@@ -45,3 +45,6 @@ spring:
 app:
   kafka:
     dlt-topic: user.create.dlt
+    atom-dlt-topic: atom.create.dlt
+    capsule-dlt-topic: capsule.create.dlt
+    growthTrack-dlt-topic: growthTrack.create.dlt


### PR DESCRIPTION
# 🚀   Pull Request: Integration of Kafka into the Roadmap Service
### 🎫   Jira Ticket
[:link:  SPRINT-2/VER-20: Consuming User events and persist them into the database](https://amali-tech.atlassian.net/browse/VER-152)
---
## :white_check_mark:  Summary
This PR provides the integration for kafka events  `atom.create`  in Roadmap service to consume the event and persist the information into the database.
---
## :pushpin:  Features  Added
- [x] `AtomKafkaConsumer` to listen and consume events
- [x] Service logic to persist the Atom information in the database
- [x] `GlobalExceptionHandler` for handling exceptions across the application
- [x] Updated `ApiResponseDto` to remove redudant methods
- [x] Proper mapping using `mapstruct` for performance optimization 
---
## 🚧  Next Task
- Integrating `skill-taxonomy` event `capsule.create` into `roadmap-service`