### PR TITLE
Feat: Kafka Integration VER-152

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.common</groupId>
             <artifactId>versapath-events</artifactId>
-            <version>2.2</version>
+            <version>2.2.2</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/exception/CapsuleAtomMappingException.java
+++ b/src/main/java/com/capstone/exception/CapsuleAtomMappingException.java
@@ -1,0 +1,22 @@
+package com.capstone.exception;
+
+import java.util.UUID;
+
+public class CapsuleAtomMappingException extends RuntimeException {
+
+    public CapsuleAtomMappingException(String message) {
+        super(message);
+    }
+
+    public CapsuleAtomMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CapsuleAtomMappingException(UUID capsuleId, UUID atomId, String reason) {
+        super("Failed to map atom " + atomId + " to capsule " + capsuleId + ": " + reason);
+    }
+
+    public CapsuleAtomMappingException(UUID capsuleId, Integer sequenceOrder, String reason) {
+        super("Failed to process sequence " + sequenceOrder + " for capsule " + capsuleId + ": " + reason);
+    }
+}

--- a/src/main/java/com/capstone/exception/DuplicateSkillCapsuleException.java
+++ b/src/main/java/com/capstone/exception/DuplicateSkillCapsuleException.java
@@ -1,0 +1,22 @@
+package com.capstone.exception;
+
+import java.util.UUID;
+
+public class DuplicateSkillCapsuleException extends RuntimeException {
+
+    public DuplicateSkillCapsuleException(String message) {
+        super(message);
+    }
+
+    public DuplicateSkillCapsuleException(UUID skillCapsuleId) {
+        super("Skill capsule already exists with ID: " + skillCapsuleId);
+    }
+
+    public DuplicateSkillCapsuleException(String field, String value) {
+        super("Skill capsule already exists with " + field + ": " + value);
+    }
+
+    public DuplicateSkillCapsuleException(String field, Object value) {
+        super("Skill capsule already exists with " + field + ": " + value);
+    }
+}

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -118,4 +118,33 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponseDto.error(ex.getMessage(), "Skill atom processing failed"));
     }
+
+    // SkillCapsule Exceptions
+    @ExceptionHandler(SkillCapsuleNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleSkillCapsuleNotFoundException(SkillCapsuleNotFoundException ex) {
+        log.error("Skill capsule not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseDto.error(ex.getMessage(), "Skill capsule not found"));
+    }
+
+    @ExceptionHandler(DuplicateSkillCapsuleException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleDuplicateSkillCapsuleException(DuplicateSkillCapsuleException ex) {
+        log.error("Duplicate skill capsule error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(ex.getMessage(), "Duplicate skill capsule"));
+    }
+
+    @ExceptionHandler(SkillCapsuleProcessingException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleSkillCapsuleProcessingException(SkillCapsuleProcessingException ex) {
+        log.error("Skill capsule processing error: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponseDto.error(ex.getMessage(), "Skill capsule processing failed"));
+    }
+
+    @ExceptionHandler(CapsuleAtomMappingException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleCapsuleAtomMappingException(CapsuleAtomMappingException ex) {
+        log.error("Capsule-atom mapping error: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ApiResponseDto.error(ex.getMessage(), "Capsule-atom mapping failed"));
+    }
 }

--- a/src/main/java/com/capstone/exception/SkillCapsuleNotFoundException.java
+++ b/src/main/java/com/capstone/exception/SkillCapsuleNotFoundException.java
@@ -1,0 +1,22 @@
+package com.capstone.exception;
+
+import java.util.UUID;
+
+public class SkillCapsuleNotFoundException extends RuntimeException {
+
+    public SkillCapsuleNotFoundException(String message) {
+        super(message);
+    }
+
+    public SkillCapsuleNotFoundException(UUID skillCapsuleId) {
+        super("Skill capsule not found with ID: " + skillCapsuleId);
+    }
+
+    public SkillCapsuleNotFoundException(String field, String value) {
+        super("Skill capsule not found with " + field + ": " + value);
+    }
+
+    public SkillCapsuleNotFoundException(String field, Object value) {
+        super("Skill capsule not found with " + field + ": " + value);
+    }
+}

--- a/src/main/java/com/capstone/exception/SkillCapsuleProcessingException.java
+++ b/src/main/java/com/capstone/exception/SkillCapsuleProcessingException.java
@@ -1,0 +1,16 @@
+package com.capstone.exception;
+
+public class SkillCapsuleProcessingException extends RuntimeException {
+
+    public SkillCapsuleProcessingException(String message) {
+        super(message);
+    }
+
+    public SkillCapsuleProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SkillCapsuleProcessingException(Throwable cause) {
+        super("Failed to process skill capsule event", cause);
+    }
+}

--- a/src/main/java/com/capstone/mapper/SkillCapsuleEventMapper.java
+++ b/src/main/java/com/capstone/mapper/SkillCapsuleEventMapper.java
@@ -1,0 +1,34 @@
+package com.capstone.mapper;
+
+import com.capstone.model.SkillCapsuleSnapshot;
+import org.common.event.SkillCapsuleEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface SkillCapsuleEventMapper {
+
+
+    @Mapping(source = "id", target = "skillCapsuleId")
+    @Mapping(source = "name", target = "capsuleName")
+    @Mapping(source = "difficulty", target = "difficultyLevel")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "learnerCapsuleProgresses", ignore = true)
+    @Mapping(target = "capsuleAtomMappings", ignore = true)
+    SkillCapsuleSnapshot toSkillCapsuleSnapshot(SkillCapsuleEvent event);
+
+
+    @Mapping(source = "name", target = "capsuleName")
+    @Mapping(source = "difficulty", target = "difficultyLevel")
+    @Mapping(target = "skillCapsuleId", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "learnerCapsuleProgresses", ignore = true)
+    @Mapping(target = "capsuleAtomMappings", ignore = true)
+    void updateSkillCapsuleSnapshot(SkillCapsuleEvent event, @MappingTarget SkillCapsuleSnapshot skillCapsuleSnapshot);
+}
+

--- a/src/main/java/com/capstone/messaging/AtomKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/AtomKafkaConsumer.java
@@ -24,10 +24,10 @@ public class AtomKafkaConsumer {
     private final SkillAtomSnapshotService skillAtomSnapshotService;
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    @Value("${app.kafka.atom-dlt-topic:atom.create.dlt}")
+    @Value("${KAFKA_ATOM_DLT_TOPIC:atom.create.dlt}")
     private String atomDltTopic;
 
-    @KafkaListener(topics = "atom.create")
+    @KafkaListener(topics = "${KAFKA_ATOM_TOPIC:atom.create}")
     @Retryable(
             retryFor = {SkillAtomProcessingException.class, Exception.class},
             backoff = @Backoff(delay = 1000, multiplier = 2)

--- a/src/main/java/com/capstone/messaging/CapsuleKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/CapsuleKafkaConsumer.java
@@ -1,0 +1,208 @@
+package com.capstone.messaging;
+
+import com.capstone.exception.CapsuleAtomMappingException;
+import com.capstone.exception.SkillAtomNotFoundException;
+import com.capstone.exception.SkillCapsuleProcessingException;
+import com.capstone.model.SkillCapsuleSnapshot;
+import com.capstone.service.SkillCapsuleSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.SkillCapsuleEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CapsuleKafkaConsumer {
+    private final SkillCapsuleSnapshotService skillCapsuleSnapshotService;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${KAFKA_CAPSULE_DLT_TOPIC:capsule.create.dlt}")
+    private String capsuleDltTopic;
+
+    @KafkaListener(topics = "${KAFKA_CAPSULE_TOPIC:capsule.create}")
+    @Retryable(
+            retryFor = {SkillCapsuleProcessingException.class, CapsuleAtomMappingException.class, Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenCapsuleCreate(
+            @Payload SkillCapsuleEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received capsule.create event from topic: {}, partition: {}, offset: {}, capsuleId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+
+            validateSkillCapsuleEvent(event);
+
+            // Process the skill capsule event
+            SkillCapsuleSnapshot processedCapsule = skillCapsuleSnapshotService.processSkillCapsuleEvent(event);
+
+            log.info("Successfully processed skill capsule event for capsuleId: {}, internal ID: {}, atoms: {}",
+                    event.getId(), processedCapsule.getId(),
+                    event.getSkillAtom() != null ? event.getSkillAtom().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (SkillCapsuleProcessingException e) {
+            log.error("Failed to process skill capsule event for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (CapsuleAtomMappingException e) {
+            log.error("Failed to process capsule-atom mappings for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (SkillAtomNotFoundException e) {
+            log.error("Missing skill atom reference for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (Exception e) {
+            log.error("Unexpected error processing skill capsule event for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+        }
+    }
+
+    /**
+     * Comprehensive validation of SkillCapsuleEvent
+     */
+    private void validateSkillCapsuleEvent(SkillCapsuleEvent event) {
+        log.debug("Validating skill capsule event: {}", event);
+
+        // Basic event validation
+        if (event == null) {
+            throw new SkillCapsuleProcessingException("Skill capsule event cannot be null");
+        }
+
+        if (event.getId() == null) {
+            throw new SkillCapsuleProcessingException("Skill capsule event must contain a valid ID");
+        }
+
+        if (event.getName() == null || event.getName().trim().isEmpty()) {
+            throw new SkillCapsuleProcessingException("Skill capsule event must contain a valid name");
+        }
+
+        // Optional field validations
+        if (event.getMoodleCourseId() < 0) {
+            throw new SkillCapsuleProcessingException("Moodle course ID must be non-negative if provided");
+        }
+
+        if (event.getDifficulty() != null && event.getDifficulty().trim().isEmpty()) {
+            throw new SkillCapsuleProcessingException("Difficulty level cannot be empty if provided");
+        }
+
+        if (event.getProficiencyLevel() != null && event.getProficiencyLevel().trim().isEmpty()) {
+            throw new SkillCapsuleProcessingException("Proficiency level cannot be empty if provided");
+        }
+
+        // Validate skillAtom list structure - O(m) where m = number of atom mappings
+        if (event.getSkillAtom() != null) {
+            validateSkillAtomMappings(event.getSkillAtom(), event.getId());
+        }
+
+        log.debug("Skill capsule event validation successful for capsuleId: {}", event.getId());
+    }
+
+    /**
+     * Validate skillAtom mapping structure and business rules
+     */
+    private void validateSkillAtomMappings(List<Map<UUID, Integer>> skillAtomMappings, UUID capsuleId) {
+        if (skillAtomMappings.isEmpty()) {
+            log.warn("Skill capsule {} has empty skillAtom list - no learning path defined", capsuleId);
+            return;
+        }
+
+        Set<UUID> atomIds = new HashSet<>();
+        Set<Integer> sequences = new HashSet<>();
+
+        for (Map<UUID, Integer> atomMap : skillAtomMappings) {
+            if (atomMap == null || atomMap.isEmpty()) {
+                throw new SkillCapsuleProcessingException("Skill atom mapping cannot be null or empty");
+            }
+
+            if (atomMap.size() != 1) {
+                throw new SkillCapsuleProcessingException("Each skill atom mapping must contain exactly one atom-sequence pair");
+            }
+
+            for (Map.Entry<UUID, Integer> entry : atomMap.entrySet()) {
+                UUID atomId = entry.getKey();
+                Integer sequence = getSequence(entry, atomId);
+
+                // Check for duplicate atom IDs
+                if (!atomIds.add(atomId)) {
+                    throw new SkillCapsuleProcessingException("Duplicate skill atom ID found: " + atomId);
+                }
+
+                // Check for duplicate sequence orders
+                if (!sequences.add(sequence)) {
+                    throw new SkillCapsuleProcessingException("Duplicate sequence order found: " + sequence);
+                }
+            }
+        }
+
+        log.debug("Validated {} skill atom mappings for capsule {}", skillAtomMappings.size(), capsuleId);
+    }
+
+    private static Integer getSequence(Map.Entry<UUID, Integer> entry, UUID atomId) {
+        Integer sequence = entry.getValue();
+
+        // Validate atom ID
+        if (atomId == null) {
+            throw new SkillCapsuleProcessingException("Skill atom ID cannot be null");
+        }
+
+        // Validate sequence order
+        if (sequence == null || sequence < 1) {
+            throw new SkillCapsuleProcessingException("Sequence order must be a positive integer, got: " + sequence);
+        }
+        return sequence;
+    }
+
+    /**
+     * Handle processing failures with DLT support
+     */
+    private void handleProcessingFailure(SkillCapsuleEvent event, Acknowledgment acknowledgment) {
+        String capsuleId = event.getId().toString();
+
+        log.error("Processing failed for skill capsule event with capsuleId: {}. Sending to DLT topic: {}",
+                capsuleId, capsuleDltTopic);
+
+        try {
+            // Send to Dead Letter Topic for manual review/reprocessing - O(1)
+            kafkaTemplate.send(capsuleDltTopic, capsuleId, event)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            log.info("Successfully sent failed skill capsule event to DLT for capsuleId: {}", capsuleId);
+                        } else {
+                            log.error("Failed to send skill capsule event to DLT for capsuleId: {}", capsuleId, ex);
+                        }
+                    });
+
+            // Acknowledge the original message to prevent infinite retries
+            acknowledgment.acknowledge();
+
+        } catch (Exception dltException) {
+            log.error("Critical: Failed to send skill capsule message to DLT for capsuleId: {}. Message will be retried by Kafka",
+                    capsuleId, dltException);
+        }
+    }
+}

--- a/src/main/java/com/capstone/messaging/UserKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/UserKafkaConsumer.java
@@ -25,10 +25,10 @@ public class UserKafkaConsumer {
     private final UserSnapshotService userSnapshotService;
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    @Value("${app.kafka.dlt-topic:user.create.dlt}")
+    @Value("${KAFKA_USER_DLT_TOPIC:user.create.dlt}")
     private String dltTopic;
 
-    @KafkaListener(topics = "user.create")
+    @KafkaListener(topics ="${KAFKA_USER_TOPIC:user.create}")
     @Retryable(
             retryFor = {UserProcessingException.class, Exception.class},
             backoff = @Backoff(delay = 1000, multiplier = 2)

--- a/src/main/java/com/capstone/model/CapsuleAtomMapping.java
+++ b/src/main/java/com/capstone/model/CapsuleAtomMapping.java
@@ -1,0 +1,95 @@
+package com.capstone.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "capsule_atom_mapping",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_capsule_atom",
+                        columnNames = {"skill_capsule_id", "skill_atom_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_capsule_sequence",
+                        columnNames = {"skill_capsule_id", "sequence_order"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_capsule_id", columnList = "skill_capsule_id"),
+                @Index(name = "idx_atom_id", columnList = "skill_atom_id"),
+                @Index(name = "idx_sequence", columnList = "skill_capsule_id, sequence_order")
+        }
+)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(exclude = {"skillCapsule", "skillAtom"})
+public class CapsuleAtomMapping {
+
+    @Id
+    @UuidGenerator
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    // Many-to-One relationship with SkillCapsuleSnapshot
+    @NotNull(message = "Skill capsule is required")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "skill_capsule_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_capsule_mapping_capsule")
+    )
+    private SkillCapsuleSnapshot skillCapsule;
+
+    // Many-to-One relationship with SkillAtomSnapshot
+    @NotNull(message = "Skill atom is required")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "skill_atom_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_capsule_mapping_atom")
+    )
+    private SkillAtomSnapshot skillAtom;
+
+    // Sequence order for learning path
+    @NotNull(message = "Sequence order is required")
+    @Min(value = 1, message = "Sequence order must be at least 1")
+    @Column(name = "sequence_order", nullable = false)
+    private Integer sequenceOrder;
+
+    // Audit fields
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // Convenience methods for business logic
+    public UUID getSkillCapsuleId() {
+        return skillCapsule != null ? skillCapsule.getSkillCapsuleId() : null;
+    }
+
+    public UUID getSkillAtomId() {
+        return skillAtom != null ? skillAtom.getSkillAtomId() : null;
+    }
+}

--- a/src/main/java/com/capstone/model/SkillCapsuleSnapshot.java
+++ b/src/main/java/com/capstone/model/SkillCapsuleSnapshot.java
@@ -3,10 +3,12 @@ package com.capstone.model;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -17,7 +19,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString(exclude = "learnerCapsuleProgresses")
+@ToString(exclude = {"learnerCapsuleProgresses", "capsuleAtomMappings"})
 public class SkillCapsuleSnapshot {
 
     @Id
@@ -25,27 +27,52 @@ public class SkillCapsuleSnapshot {
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
+    @NotNull(message = "Skill capsule ID is required")
+    @Column(nullable = false, unique = true, updatable = false, name = "skill_capsule_id")
+    private UUID skillCapsuleId;
+
     @NotBlank(message = "Capsule name is required")
     @Size(max = 255, message = "Capsule name must not exceed 255 characters")
-    @Column(name = "capsule_name", nullable = false, length = 255)
+    @Column(name = "capsule_name", nullable = false)
     private String capsuleName;
-
-    @Size(max = 100, message = "Category type must not exceed 100 characters")
-    @Column(name = "category_type", length = 100)
-    private String categoryType;
 
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
-    @Min(value = 1, message = "Estimated hours must be at least 1")
-    @Column(name = "estimated_hours", nullable = false)
-    private Integer estimatedHours;
-
     @Column(name = "difficulty_level", length = 20)
     private String difficultyLevel;
+
+    @Column(name = "moodle_course_id")
+    private Integer moodleCourseId;
+
+    @Size(max = 50, message = "Proficiency level must not exceed 50 characters")
+    @Column(name = "proficiency_level", length = 50)
+    private String proficiencyLevel;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "skillCapsule", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<LearnerCapsuleProgress> learnerCapsuleProgresses = new ArrayList<>();
+
+    @OneToMany(mappedBy = "skillCapsule", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @OrderBy("sequenceOrder ASC")
+    @Builder.Default
+    private List<CapsuleAtomMapping> capsuleAtomMappings = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/capstone/repository/SkillCapsuleSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/SkillCapsuleSnapshotRepository.java
@@ -2,10 +2,23 @@ package com.capstone.repository;
 
 import com.capstone.model.SkillCapsuleSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface SkillCapsuleSnapshotRepository extends JpaRepository<SkillCapsuleSnapshot, UUID> {
+
+    Optional<SkillCapsuleSnapshot> findBySkillCapsuleId(UUID skillCapsuleId);
+    boolean existsBySkillCapsuleId(UUID skillCapsuleId);
+
+    @Query("SELECT DISTINCT c FROM SkillCapsuleSnapshot c " +
+            "LEFT JOIN FETCH c.capsuleAtomMappings cam " +
+            "LEFT JOIN FETCH cam.skillAtom " +
+            "WHERE c.skillCapsuleId = :skillCapsuleId " +
+            "ORDER BY cam.sequenceOrder ASC")
+    Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(@Param("skillCapsuleId") UUID skillCapsuleId);
 }

--- a/src/main/java/com/capstone/service/SkillCapsuleSnapshotService.java
+++ b/src/main/java/com/capstone/service/SkillCapsuleSnapshotService.java
@@ -1,0 +1,20 @@
+package com.capstone.service;
+
+import com.capstone.model.SkillCapsuleSnapshot;
+import org.common.event.SkillCapsuleEvent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SkillCapsuleSnapshotService {
+
+    SkillCapsuleSnapshot processSkillCapsuleEvent(SkillCapsuleEvent event);
+    SkillCapsuleSnapshot createSkillCapsule(SkillCapsuleEvent event);
+    SkillCapsuleSnapshot updateSkillCapsule(SkillCapsuleSnapshot existingCapsule, SkillCapsuleEvent event);
+    void smartUpdateCapsuleAtomMappings(SkillCapsuleSnapshot capsule, List<Map<UUID, Integer>> skillAtomMappings);
+    Optional<SkillCapsuleSnapshot> findBySkillCapsuleId(UUID skillCapsuleId);
+    boolean existsBySkillCapsuleId(UUID skillCapsuleId);
+    Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(UUID skillCapsuleId);
+}

--- a/src/main/java/com/capstone/service/impl/SkillCapsuleSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/SkillCapsuleSnapshotServiceImpl.java
@@ -1,0 +1,259 @@
+package com.capstone.service.impl;
+
+import com.capstone.exception.*;
+import com.capstone.mapper.SkillCapsuleEventMapper;
+import com.capstone.model.CapsuleAtomMapping;
+import com.capstone.model.SkillAtomSnapshot;
+import com.capstone.model.SkillCapsuleSnapshot;
+import com.capstone.repository.SkillCapsuleSnapshotRepository;
+import com.capstone.service.SkillAtomSnapshotService;
+import com.capstone.service.SkillCapsuleSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.SkillCapsuleEvent;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class SkillCapsuleSnapshotServiceImpl implements SkillCapsuleSnapshotService {
+
+    private final SkillCapsuleSnapshotRepository skillCapsuleSnapshotRepository;
+    private final SkillCapsuleEventMapper skillCapsuleEventMapper;
+    private final SkillAtomSnapshotService skillAtomSnapshotService;
+
+    @Override
+    public SkillCapsuleSnapshot processSkillCapsuleEvent(SkillCapsuleEvent event) {
+        log.info("Processing skill capsule event for capsuleId: {}", event.getId());
+
+        try {
+            Optional<SkillCapsuleSnapshot> existingCapsule = skillCapsuleSnapshotRepository.findBySkillCapsuleId(event.getId());
+
+            if (existingCapsule.isPresent()) {
+                log.info("Capsule exists, updating capsule with ID: {}", event.getId());
+                return updateSkillCapsule(existingCapsule.get(), event);
+            } else {
+                log.info("Capsule does not exist, creating new capsule with ID: {}", event.getId());
+                return createSkillCapsule(event);
+            }
+
+        } catch (Exception e) {
+            log.error("Error processing skill capsule event for capsuleId: {}", event.getId(), e);
+            throw new SkillCapsuleProcessingException("Failed to process skill capsule event", e);
+        }
+    }
+
+    @Override
+    public SkillCapsuleSnapshot createSkillCapsule(SkillCapsuleEvent event) {
+        log.debug("Creating new skill capsule from event: {}", event);
+
+        try {
+
+            SkillCapsuleSnapshot newCapsule = skillCapsuleEventMapper.toSkillCapsuleSnapshot(event);
+            SkillCapsuleSnapshot savedCapsule = skillCapsuleSnapshotRepository.save(newCapsule);
+            log.info("Successfully created skill capsule with ID: {}", savedCapsule.getSkillCapsuleId());
+
+            //Process atom mappings
+            if (event.getSkillAtom() != null && !event.getSkillAtom().isEmpty()) {
+                smartUpdateCapsuleAtomMappings(savedCapsule, event.getSkillAtom());
+                log.info("Successfully created {} atom mappings for capsule {}",
+                        event.getSkillAtom().size(), savedCapsule.getSkillCapsuleId());
+            }
+
+            return savedCapsule;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when creating capsule with ID: {}", event.getId(), e);
+            throw new DuplicateSkillCapsuleException(event.getId());
+        } catch (Exception e) {
+            log.error("Unexpected error creating capsule with ID: {}", event.getId(), e);
+            throw new SkillCapsuleProcessingException("Failed to create skill capsule", e);
+        }
+    }
+
+    @Override
+    public SkillCapsuleSnapshot updateSkillCapsule(SkillCapsuleSnapshot existingCapsule, SkillCapsuleEvent event) {
+        log.debug("Updating existing capsule {} with event data", existingCapsule.getSkillCapsuleId());
+
+        try {
+
+            skillCapsuleEventMapper.updateSkillCapsuleSnapshot(event, existingCapsule);
+            SkillCapsuleSnapshot updatedCapsule = skillCapsuleSnapshotRepository.save(existingCapsule);
+
+            //Smart update atom mappings
+            if (event.getSkillAtom() != null && !event.getSkillAtom().isEmpty()) {
+                smartUpdateCapsuleAtomMappings(updatedCapsule, event.getSkillAtom());
+                log.info("Successfully updated atom mappings for capsule {}", updatedCapsule.getSkillCapsuleId());
+            }
+
+            log.info("Successfully updated skill capsule with ID: {}", updatedCapsule.getSkillCapsuleId());
+            return updatedCapsule;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when updating capsule with ID: {}", existingCapsule.getSkillCapsuleId(), e);
+            throw new SkillCapsuleProcessingException("Capsule update failed due to data constraint violation", e);
+        } catch (Exception e) {
+            log.error("Unexpected error updating capsule with ID: {}", existingCapsule.getSkillCapsuleId(), e);
+            throw new SkillCapsuleProcessingException("Failed to update skill capsule", e);
+        }
+    }
+
+    @Override
+    public void smartUpdateCapsuleAtomMappings(SkillCapsuleSnapshot capsule, List<Map<UUID, Integer>> skillAtomMappings) {
+        log.debug("Smart updating atom mappings for capsule: {}", capsule.getSkillCapsuleId());
+
+        try {
+            // PHASE 1: VERIFY ALL ATOMS EXIST - Fail Fast Strategy
+            List<AtomSequencePair> newMappings = verifyAndParseAtoms(skillAtomMappings);
+            log.debug("Verified {} atom mappings for capsule {}", newMappings.size(), capsule.getSkillCapsuleId());
+
+            // PHASE 2: ANALYZE CHANGES - Smart Diff Algorithm
+            UpdateAnalysis analysis = analyzeChanges(capsule, newMappings);
+            log.debug("Analysis for capsule {}: {} to add, {} to update",
+                    capsule.getSkillCapsuleId(), analysis.getToAdd().size(), analysis.getToUpdate().size());
+
+            // PHASE 3: APPLY UPDATES - Atomic Operation
+            applyAtomMappingUpdates(capsule, analysis);
+
+            log.info("Smart update completed for capsule {}: {} added, {} updated, {} preserved",
+                    capsule.getSkillCapsuleId(), analysis.getToAdd().size(),
+                    analysis.getToUpdate().size(), analysis.getPreserved());
+
+        } catch (SkillAtomNotFoundException e) {
+            log.error("Atom verification failed for capsule {}: {}", capsule.getSkillCapsuleId(), e.getMessage());
+            throw new CapsuleAtomMappingException("Atom not found: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Smart update failed for capsule {}: {}", capsule.getSkillCapsuleId(), e.getMessage(), e);
+            throw new CapsuleAtomMappingException( "Smart update failed", e);
+        }
+    }
+
+    /**
+     * Verify all atoms exist and parse into structured format
+     */
+    private List<AtomSequencePair> verifyAndParseAtoms(List<Map<UUID, Integer>> skillAtomMappings) {
+        List<AtomSequencePair> parsedMappings = new ArrayList<>();
+
+        for (Map<UUID, Integer> atomMap : skillAtomMappings) {
+            for (Map.Entry<UUID, Integer> entry : atomMap.entrySet()) {
+                UUID atomId = entry.getKey();
+                Integer sequence = entry.getValue();
+
+                // Verify atom exists
+                SkillAtomSnapshot atom = skillAtomSnapshotService.findBySkillAtomId(atomId)
+                        .orElseThrow(() -> new SkillAtomNotFoundException(atomId));
+
+                // Validate sequence order
+                if (sequence == null || sequence < 1) {
+                    throw new CapsuleAtomMappingException(null, atomId, "Invalid sequence order: " + sequence);
+                }
+
+                parsedMappings.add(new AtomSequencePair(atom, sequence));
+            }
+        }
+
+        return parsedMappings;
+    }
+
+    /**
+     * Analyze differences between existing and new mappings
+     */
+    private UpdateAnalysis analyzeChanges(SkillCapsuleSnapshot capsule, List<AtomSequencePair> newMappings) {
+        // Build lookup map of existing mappings - O(n)
+        Map<UUID, CapsuleAtomMapping> existingMap = capsule.getCapsuleAtomMappings()
+                .stream()
+                .collect(Collectors.toMap(
+                        mapping -> mapping.getSkillAtom().getSkillAtomId(),
+                        mapping -> mapping
+                ));
+
+        List<CapsuleAtomMapping> toAdd = new ArrayList<>();
+        List<CapsuleAtomMapping> toUpdate = new ArrayList<>();
+        int preserved = 0;
+
+        // Process each new mapping - O(m)
+        for (AtomSequencePair newMapping : newMappings) {
+            UUID atomId = newMapping.getAtom().getSkillAtomId();
+
+            if (existingMap.containsKey(atomId)) {
+                // ATOM EXISTS - Check if sequence changed
+                CapsuleAtomMapping existing = existingMap.get(atomId);
+                if (!existing.getSequenceOrder().equals(newMapping.getSequence())) {
+                    existing.setSequenceOrder(newMapping.getSequence());
+                    toUpdate.add(existing);
+                } else {
+                    preserved++; // No change needed
+                }
+                // Remove from map to track what remains
+                existingMap.remove(atomId);
+            } else {
+                // NEW ATOM - Create mapping
+                CapsuleAtomMapping newMappingEntity = CapsuleAtomMapping.builder()
+                        .skillCapsule(capsule)
+                        .skillAtom(newMapping.getAtom())
+                        .sequenceOrder(newMapping.getSequence())
+                        .build();
+                toAdd.add(newMappingEntity);
+            }
+        }
+
+        // Remaining mappings in existingMap are preserved (not in new event)
+        preserved += existingMap.size();
+
+        return new UpdateAnalysis(toAdd, toUpdate, preserved);
+    }
+
+    /**
+     * Apply the analyzed updates to the capsule
+     */
+    private void applyAtomMappingUpdates(SkillCapsuleSnapshot capsule, UpdateAnalysis analysis) {
+        if (!analysis.getToAdd().isEmpty()) {
+            capsule.getCapsuleAtomMappings().addAll(analysis.getToAdd());
+        }
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<SkillCapsuleSnapshot> findBySkillCapsuleId(UUID skillCapsuleId) {
+        log.debug("Finding capsule by skillCapsuleId: {}", skillCapsuleId);
+        return skillCapsuleSnapshotRepository.findBySkillCapsuleId(skillCapsuleId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsBySkillCapsuleId(UUID skillCapsuleId) {
+        log.debug("Checking if capsule exists by skillCapsuleId: {}", skillCapsuleId);
+        return skillCapsuleSnapshotRepository.existsBySkillCapsuleId(skillCapsuleId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(UUID skillCapsuleId) {
+        log.debug("Finding capsule with atom mappings by skillCapsuleId: {}", skillCapsuleId);
+        return skillCapsuleSnapshotRepository.findBySkillCapsuleIdWithAtomMappings(skillCapsuleId);
+    }
+
+    // Helper classes
+
+    @lombok.Data
+    @lombok.AllArgsConstructor
+    private static class AtomSequencePair {
+        private SkillAtomSnapshot atom;
+        private Integer sequence;
+    }
+
+    @lombok.Data
+    @lombok.AllArgsConstructor
+    private static class UpdateAnalysis {
+        private List<CapsuleAtomMapping> toAdd;
+        private List<CapsuleAtomMapping> toUpdate;
+        private int preserved;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     import: optional:configserver:${CONFIG_SERVER_URL}
 
   kafka:
-    bootstrap-servers: pkc-619z3.us-east1.gcp.confluent.cloud:9092
+    bootstrap-servers: ${BOOTSTRAP_SERVER}
     properties:
       sasl.mechanism: PLAIN
       security.protocol: SASL_SSL
@@ -44,7 +44,8 @@ spring:
 
 app:
   kafka:
-    dlt-topic: user.create.dlt
-    atom-dlt-topic: atom.create.dlt
-    capsule-dlt-topic: capsule.create.dlt
-    growthTrack-dlt-topic: growthTrack.create.dlt
+    dlt-topic: ${KAFKA_USER_DLT_TOPIC}
+    atom-dlt-topic: ${KAFKA_ATOM_DLT_TOPIC}
+    capsule-dlt-topic: ${KAFKA_CAPSULE_DLT_TOPIC}
+    growthTrack-dlt-topic: ${KAFKA_GROWTH_TRACK_DLT_TOPIC}
+    talentRoute-dlt-topic: ${KAFKA_TALENT_ROUTE_DLT_TOPIC}


### PR DESCRIPTION
# 🚀   Pull Request: Integration of Kafka into the Roadmap Service
### 🎫   Jira Ticket
[:link:  SPRINT-2/VER-20: Consuming Kafka events and persist them into the database](https://amali-tech.atlassian.net/browse/VER-152)
---
## :white_check_mark:  Summary
This PR provides the integration for kafka events  `capsule.create`  in Roadmap service to consume the event and persist the information into the database.
---
## :pushpin:  Features  Added
- [x] `CapsuleKafkaConsumer` to listen and consume events
- [x] Service logic to persist the Capsules with it's mapped atom in the database
- [x] Smart update logic for atom relationships
- [x] `GlobalExceptionHandler` for handling exceptions across the application
- [x] Proper mapping using `mapstruct` for performance optimization 
---
## 🚧  Next Task
- Integrating `skill-taxonomy` event `growthTrack.create` into `roadmap-service`