### PR TITLE
Feat:Kafka Integration VER-152

### DIFF
--- a/src/main/java/com/capstone/exception/DuplicateTalentRouteException.java
+++ b/src/main/java/com/capstone/exception/DuplicateTalentRouteException.java
@@ -1,0 +1,18 @@
+package com.capstone.exception;
+
+import java.util.UUID;
+
+public class DuplicateTalentRouteException extends RuntimeException {
+
+    public DuplicateTalentRouteException(String message) {
+        super(message);
+    }
+
+    public DuplicateTalentRouteException(UUID talentRouteId) {
+        super("Talent route with ID " + talentRouteId + " already exists");
+    }
+
+    public DuplicateTalentRouteException(String field, String value) {
+        super("Talent route with " + field + " '" + value + "' already exists");
+    }
+}

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -179,4 +179,27 @@ public class GlobalExceptionHandler {
                 .body(ApiResponseDto.error(ex.getMessage(), "Track-capsule mapping failed"));
     }
 
+    // GrowthTrack Exception
+
+    @ExceptionHandler(DuplicateTalentRouteException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleDuplicateGrowthTrackException(DuplicateTalentRouteException ex) {
+        log.error("Duplicate talent route error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(ex.getMessage(), "Duplicate talent route"));
+    }
+
+    @ExceptionHandler(TalentRouteProcessingException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleGrowthTrackProcessingException(TalentRouteProcessingException ex) {
+        log.error("Talent route processing error: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponseDto.error(ex.getMessage(), "Talent route processing failed"));
+    }
+
+    @ExceptionHandler(RouteTrackMappingException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleTrackCapsuleMappingException(RouteTrackMappingException ex) {
+        log.error("Route-track mapping error: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(ApiResponseDto.error(ex.getMessage(), "Route-track mapping failed"));
+    }
+
 }

--- a/src/main/java/com/capstone/exception/RouteTrackMappingException.java
+++ b/src/main/java/com/capstone/exception/RouteTrackMappingException.java
@@ -1,0 +1,22 @@
+package com.capstone.exception;
+
+import java.util.UUID;
+
+public class RouteTrackMappingException extends RuntimeException {
+
+    public RouteTrackMappingException(String message) {
+        super(message);
+    }
+
+    public RouteTrackMappingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RouteTrackMappingException(UUID routeId, UUID trackId, String reason) {
+        super("Failed to map track " + trackId + " to route " + routeId + ": " + reason);
+    }
+
+    public RouteTrackMappingException(UUID routeId, Integer sequenceOrder, String reason) {
+        super("Failed to process sequence " + sequenceOrder + " for route " + routeId + ": " + reason);
+    }
+}

--- a/src/main/java/com/capstone/exception/TalentRouteProcessingException.java
+++ b/src/main/java/com/capstone/exception/TalentRouteProcessingException.java
@@ -1,0 +1,16 @@
+package com.capstone.exception;
+
+public class TalentRouteProcessingException extends RuntimeException {
+
+    public TalentRouteProcessingException(String message) {
+        super(message);
+    }
+
+    public TalentRouteProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TalentRouteProcessingException(Throwable cause) {
+        super("Failed to process talent route event", cause);
+    }
+}

--- a/src/main/java/com/capstone/mapper/TalentRouteEventMapper.java
+++ b/src/main/java/com/capstone/mapper/TalentRouteEventMapper.java
@@ -1,0 +1,29 @@
+package com.capstone.mapper;
+
+import com.capstone.model.TalentRouteSnapshot;
+import org.common.event.TalentRouteEvent;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface TalentRouteEventMapper {
+
+    @Mapping(source = "id", target = "talentRouteId")
+    @Mapping(source = "name", target = "routeName")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "learnerRoadmaps", ignore = true)
+    @Mapping(target = "routeTrackMappings", ignore = true)
+    TalentRouteSnapshot toTalentRouteSnapshot(TalentRouteEvent event);
+
+    @Mapping(source = "name", target = "routeName")
+    @Mapping(target = "talentRouteId", ignore = true)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "learnerRoadmaps", ignore = true)
+    @Mapping(target = "routeTrackMappings", ignore = true)
+    void updateTalentRouteSnapshot(TalentRouteEvent event, @MappingTarget TalentRouteSnapshot talentRouteSnapshot);
+}

--- a/src/main/java/com/capstone/messaging/TalentRouteKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/TalentRouteKafkaConsumer.java
@@ -1,0 +1,200 @@
+package com.capstone.messaging;
+
+import com.capstone.exception.GrowthTrackNotFoundException;
+import com.capstone.exception.RouteTrackMappingException;
+import com.capstone.exception.TalentRouteProcessingException;
+import com.capstone.model.TalentRouteSnapshot;
+import com.capstone.service.TalentRouteSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.TalentRouteEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TalentRouteKafkaConsumer {
+
+    private final TalentRouteSnapshotService talentRouteSnapshotService;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${app.kafka.talentRoute-dlt-topic:talentRoute.create.dlt}")
+    private String talentRouteDltTopic;
+
+    @KafkaListener(topics = "${KAFKA_TALENT_ROUTE_TOPIC:talentRoute.create}")
+    @Retryable(
+            retryFor = {TalentRouteProcessingException.class, RouteTrackMappingException.class, Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenTalentRouteCreate(
+            @Payload TalentRouteEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received talent route event from topic: {}, partition: {}, offset: {}, routeId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate event
+            validateTalentRouteEvent(event);
+
+            // Process the talent route event
+            TalentRouteSnapshot processedRoute = talentRouteSnapshotService.processTalentRouteEvent(event);
+
+            log.info("Successfully processed talent route event for routeId: {}, internal ID: {}, tracks: {}",
+                    event.getId(), processedRoute.getId(),
+                    event.getGrowthTracks() != null ? event.getGrowthTracks().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (TalentRouteProcessingException e) {
+            log.error("Failed to process talent route event for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (RouteTrackMappingException e) {
+            log.error("Failed to process route-track mappings for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (GrowthTrackNotFoundException e) {
+            log.error("Missing growth track reference for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (Exception e) {
+            log.error("Unexpected error processing talent route event for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+        }
+    }
+
+    /**
+     * Comprehensive validation of TalentRouteEvent
+     */
+    private void validateTalentRouteEvent(TalentRouteEvent event) {
+        log.debug("Validating talent route event: {}", event);
+
+        // Basic event validation
+        if (event == null) {
+            throw new TalentRouteProcessingException("Talent route event cannot be null");
+        }
+
+        if (event.getId() == null) {
+            throw new TalentRouteProcessingException("Talent route event must contain a valid ID");
+        }
+
+        if (event.getName() == null || event.getName().trim().isEmpty()) {
+            throw new TalentRouteProcessingException("Talent route event must contain a valid name");
+        }
+
+        // Validate growthTrack list structure
+        if (event.getGrowthTracks() != null) {
+            validateGrowthTrackMappings(event.getGrowthTracks(), event.getId());
+        }
+
+        log.debug("Talent route event validation successful for routeId: {}", event.getId());
+    }
+
+    /**
+     * Validate growthTrack mapping structure and business rules
+     */
+    private void validateGrowthTrackMappings(List<Map<UUID, Integer>> growthTrackMappings, UUID routeId) {
+        if (growthTrackMappings.isEmpty()) {
+            log.warn("Talent route {} has empty growthTrack list - no learning path defined", routeId);
+            return;
+        }
+
+        Set<UUID> trackIds = new HashSet<>();
+        Set<Integer> sequences = new HashSet<>();
+
+        for (Map<UUID, Integer> trackMap : growthTrackMappings) {
+            if (trackMap == null || trackMap.isEmpty()) {
+                throw new TalentRouteProcessingException("Growth track mapping cannot be null or empty");
+            }
+
+            if (trackMap.size() != 1) {
+                throw new TalentRouteProcessingException("Each growth track mapping must contain exactly one track-sequence pair");
+            }
+
+            for (Map.Entry<UUID, Integer> entry : trackMap.entrySet()) {
+                UUID trackId = entry.getKey();
+                Integer sequence = getSequence(entry, trackId);
+
+                // Check for duplicate track IDs
+                if (!trackIds.add(trackId)) {
+                    throw new TalentRouteProcessingException("Duplicate growth track ID found: " + trackId);
+                }
+
+                // Check for duplicate sequence orders
+                if (!sequences.add(sequence)) {
+                    throw new TalentRouteProcessingException("Duplicate sequence order found: " + sequence);
+                }
+            }
+        }
+
+        log.debug("Validated {} growth track mappings for route {}", growthTrackMappings.size(), routeId);
+    }
+
+    private static Integer getSequence(Map.Entry<UUID, Integer> entry, UUID trackId) {
+        Integer sequence = entry.getValue();
+
+        // Validate track ID
+        if (trackId == null) {
+            throw new TalentRouteProcessingException("Growth track ID cannot be null");
+        }
+
+        // Validate sequence order
+        if (sequence == null || sequence < 1) {
+            throw new TalentRouteProcessingException("Sequence order must be a positive integer, got: " + sequence);
+        }
+        return sequence;
+    }
+
+    /**
+     * Handle processing failures with DLT support
+     */
+    private void handleProcessingFailure(TalentRouteEvent event, Acknowledgment acknowledgment) {
+        String routeId = event.getId().toString();
+
+        log.error("Processing failed for talent route event with routeId: {}. Sending to DLT topic: {}",
+                routeId, talentRouteDltTopic);
+
+        try {
+            // Send to Dead Letter Topic for manual review/reprocessing
+            kafkaTemplate.send(talentRouteDltTopic, routeId, event)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            log.info("Successfully sent failed talent route event to DLT for routeId: {}", routeId);
+                        } else {
+                            log.error("Failed to send talent route event to DLT for routeId: {}", routeId, ex);
+                        }
+                    });
+
+            // Acknowledge the original message to prevent infinite retries
+            acknowledgment.acknowledge();
+
+        } catch (Exception dltException) {
+            log.error("Critical: Failed to send talent route message to DLT for routeId: {}. Message will be retried by Kafka",
+                    routeId, dltException);
+        }
+    }
+}

--- a/src/main/java/com/capstone/model/RouteTrackMapping.java
+++ b/src/main/java/com/capstone/model/RouteTrackMapping.java
@@ -1,0 +1,82 @@
+package com.capstone.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "route_track_mapping",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_route_track",
+                        columnNames = {"talent_route_id", "growth_track_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_route_sequence",
+                        columnNames = {"talent_route_id", "sequence_order"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_route_id", columnList = "talent_route_id"),
+                @Index(name = "idx_track_id_route", columnList = "growth_track_id"),
+                @Index(name = "idx_route_sequence", columnList = "talent_route_id, sequence_order")
+        }
+)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(exclude = {"talentRoute", "growthTrack"})
+public class RouteTrackMapping {
+
+    @Id
+    @UuidGenerator
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @NotNull(message = "Talent route is required")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "talent_route_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_route_mapping_route")
+    )
+    private TalentRouteSnapshot talentRoute;
+
+    @NotNull(message = "Growth track is required")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "growth_track_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_route_mapping_track")
+    )
+    private GrowthTrackSnapshot growthTrack;
+
+    @NotNull(message = "Sequence order is required")
+    @Min(value = 1, message = "Sequence order must be at least 1")
+    @Column(name = "sequence_order", nullable = false)
+    private Integer sequenceOrder;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/capstone/model/TalentRouteSnapshot.java
+++ b/src/main/java/com/capstone/model/TalentRouteSnapshot.java
@@ -2,10 +2,12 @@ package com.capstone.model;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -16,27 +18,48 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ToString(exclude = "learnerRoadmaps")
+@ToString(exclude = {"learnerRoadmaps", "routeTrackMappings"})
 public class TalentRouteSnapshot {
     @Id
     @UuidGenerator
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
+    @NotNull(message = "Talent route ID is required")
+    @Column(nullable = false, unique = true, updatable = false, name = "talent_route_id")
+    private UUID talentRouteId;
+
     @NotBlank(message = "Route name is required")
     @Size(max = 50, message = "Route name must not exceed 50 characters")
     @Column(name = "route_name", nullable = false, length = 50)
     private String routeName;
 
-    @Size(max = 255, message = "Job role must not exceed 255 characters")
-    @Column(name = "job_role", length = 255)
-    private String jobRole;
-
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "talentRoute", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Builder.Default
     private List<LearnerRoadmap> learnerRoadmaps = new ArrayList<>();
 
+    @OneToMany(mappedBy = "talentRoute", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    @OrderBy("sequenceOrder ASC")
+    @Builder.Default
+    private List<RouteTrackMapping> routeTrackMappings = new ArrayList<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/capstone/repository/TalentRouteSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/TalentRouteSnapshotRepository.java
@@ -2,10 +2,24 @@ package com.capstone.repository;
 
 import com.capstone.model.TalentRouteSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface TalentRouteSnapshotRepository extends JpaRepository<TalentRouteSnapshot, UUID> {
+
+    Optional<TalentRouteSnapshot> findByTalentRouteId(UUID talentRouteId);
+
+    boolean existsByTalentRouteId(UUID talentRouteId);
+
+    @Query("SELECT DISTINCT tr FROM TalentRouteSnapshot tr " +
+            "LEFT JOIN FETCH tr.routeTrackMappings rtm " +
+            "LEFT JOIN FETCH rtm.growthTrack " +
+            "WHERE tr.talentRouteId = :talentRouteId " +
+            "ORDER BY rtm.sequenceOrder ASC")
+    Optional<TalentRouteSnapshot> findByTalentRouteIdWithTrackMappings(@Param("talentRouteId") UUID talentRouteId);
 }

--- a/src/main/java/com/capstone/service/TalentRouteSnapshotService.java
+++ b/src/main/java/com/capstone/service/TalentRouteSnapshotService.java
@@ -1,0 +1,19 @@
+package com.capstone.service;
+
+import com.capstone.model.TalentRouteSnapshot;
+import org.common.event.TalentRouteEvent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TalentRouteSnapshotService {
+    TalentRouteSnapshot processTalentRouteEvent(TalentRouteEvent event);
+    TalentRouteSnapshot createTalentRoute(TalentRouteEvent event);
+    TalentRouteSnapshot updateTalentRoute(TalentRouteSnapshot existingRoute, TalentRouteEvent event);
+    void smartUpdateRouteTrackMappings(TalentRouteSnapshot route, List<Map<UUID, Integer>> growthTrackMappings);
+    Optional<TalentRouteSnapshot> findByTalentRouteId(UUID talentRouteId);
+    boolean existsByTalentRouteId(UUID talentRouteId);
+    Optional<TalentRouteSnapshot> findByTalentRouteIdWithTrackMappings(UUID talentRouteId);
+}

--- a/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
@@ -1,0 +1,249 @@
+package com.capstone.service.impl;
+
+import com.capstone.exception.*;
+import com.capstone.mapper.TalentRouteEventMapper;
+import com.capstone.model.GrowthTrackSnapshot;
+import com.capstone.model.RouteTrackMapping;
+import com.capstone.model.TalentRouteSnapshot;
+import com.capstone.repository.TalentRouteSnapshotRepository;
+import com.capstone.service.GrowthTrackSnapshotService;
+import com.capstone.service.TalentRouteSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.common.event.TalentRouteEvent;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotService {
+
+    private final TalentRouteSnapshotRepository talentRouteSnapshotRepository;
+    private final TalentRouteEventMapper talentRouteEventMapper;
+    private final GrowthTrackSnapshotService growthTrackSnapshotService;
+
+    @Override
+    public TalentRouteSnapshot processTalentRouteEvent(TalentRouteEvent event) {
+        log.info("Processing talent route event for routeId: {}", event.getId());
+
+        try {
+            Optional<TalentRouteSnapshot> existingRoute = talentRouteSnapshotRepository.findByTalentRouteId(event.getId());
+
+            if (existingRoute.isPresent()) {
+                log.info("Route exists, updating route with ID: {}", event.getId());
+                return updateTalentRoute(existingRoute.get(), event);
+            } else {
+                log.info("Route does not exist, creating new route with ID: {}", event.getId());
+                return createTalentRoute(event);
+            }
+
+        } catch (Exception e) {
+            log.error("Error processing talent route event for routeId: {}", event.getId(), e);
+            throw new TalentRouteProcessingException("Failed to process talent route event", e);
+        }
+    }
+
+    @Override
+    public TalentRouteSnapshot createTalentRoute(TalentRouteEvent event) {
+        log.debug("Creating new talent route from event: {}", event);
+
+        try {
+            // Create basic route entity
+            TalentRouteSnapshot newRoute = talentRouteEventMapper.toTalentRouteSnapshot(event);
+            TalentRouteSnapshot savedRoute = talentRouteSnapshotRepository.save(newRoute);
+            log.info("Successfully created talent route with ID: {}", savedRoute.getTalentRouteId());
+
+            // Process track mappings
+            if (event.getGrowthTracks() != null && !event.getGrowthTracks().isEmpty()) {
+                smartUpdateRouteTrackMappings(savedRoute, event.getGrowthTracks());
+                log.info("Successfully created {} track mappings for route {}",
+                        event.getGrowthTracks().size(), savedRoute.getTalentRouteId());
+            }
+
+            return savedRoute;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when creating route with ID: {}", event.getId(), e);
+            throw new DuplicateTalentRouteException(event.getId());
+        } catch (Exception e) {
+            log.error("Unexpected error creating route with ID: {}", event.getId(), e);
+            throw new TalentRouteProcessingException("Failed to create talent route", e);
+        }
+    }
+
+    @Override
+    public TalentRouteSnapshot updateTalentRoute(TalentRouteSnapshot existingRoute, TalentRouteEvent event) {
+        log.debug("Updating existing route {} with event data", existingRoute.getTalentRouteId());
+
+        try {
+            // Update basic route fields
+            talentRouteEventMapper.updateTalentRouteSnapshot(event, existingRoute);
+            TalentRouteSnapshot updatedRoute = talentRouteSnapshotRepository.save(existingRoute);
+
+            // Smart update track mappings
+            if (event.getGrowthTracks() != null && !event.getGrowthTracks().isEmpty()) {
+                smartUpdateRouteTrackMappings(updatedRoute, event.getGrowthTracks());
+                log.info("Successfully updated track mappings for route {}", updatedRoute.getTalentRouteId());
+            }
+
+            log.info("Successfully updated talent route with ID: {}", updatedRoute.getTalentRouteId());
+            return updatedRoute;
+
+        } catch (DataIntegrityViolationException e) {
+            log.error("Data integrity violation when updating route with ID: {}", existingRoute.getTalentRouteId(), e);
+            throw new TalentRouteProcessingException("Route update failed due to data constraint violation", e);
+        } catch (Exception e) {
+            log.error("Unexpected error updating route with ID: {}", existingRoute.getTalentRouteId(), e);
+            throw new TalentRouteProcessingException("Failed to update talent route", e);
+        }
+    }
+
+    @Override
+    public void smartUpdateRouteTrackMappings(TalentRouteSnapshot route, List<Map<UUID, Integer>> growthTrackMappings) {
+        log.debug("Smart updating track mappings for route: {}", route.getTalentRouteId());
+
+        try {
+            // PHASE 1: VERIFY ALL TRACKS EXIST - Fail Fast Strategy
+            List<TrackSequencePair> newMappings = verifyAndParseTracks(growthTrackMappings);
+            log.debug("Verified {} track mappings for route {}", newMappings.size(), route.getTalentRouteId());
+
+            // PHASE 2: ANALYZE CHANGES - Smart Diff Algorithm
+            UpdateAnalysis analysis = analyzeChanges(route, newMappings);
+            log.debug("Analysis for route {}: {} to add, {} to update",
+                    route.getTalentRouteId(), analysis.getToAdd().size(), analysis.getToUpdate().size());
+
+            // PHASE 3: APPLY UPDATES - Atomic Operation
+            applyRouteTrackMappingUpdates(route, analysis);
+
+            log.info("Smart update completed for route {}: {} added, {} updated, {} preserved",
+                    route.getTalentRouteId(), analysis.getToAdd().size(),
+                    analysis.getToUpdate().size(), analysis.getPreserved());
+
+        } catch (GrowthTrackNotFoundException e) {
+            log.error("Track verification failed for route {}: {}", route.getTalentRouteId(), e.getMessage());
+            throw new RouteTrackMappingException("Growth track not found: " + e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Smart update failed for route {}: {}", route.getTalentRouteId(), e.getMessage(), e);
+            throw new RouteTrackMappingException("Smart update failed", e);
+        }
+    }
+
+    private List<TrackSequencePair> verifyAndParseTracks(List<Map<UUID, Integer>> growthTrackMappings) {
+        List<TrackSequencePair> parsedMappings = new ArrayList<>();
+
+        for (Map<UUID, Integer> trackMap : growthTrackMappings) {
+            for (Map.Entry<UUID, Integer> entry : trackMap.entrySet()) {
+                UUID trackId = entry.getKey();
+                Integer sequence = entry.getValue();
+
+                // Verify track exists
+                GrowthTrackSnapshot track = growthTrackSnapshotService.findByGrowthTrackId(trackId)
+                        .orElseThrow(() -> new GrowthTrackNotFoundException(trackId));
+
+                // Validate sequence order
+                if (sequence == null || sequence < 1) {
+                    throw new RouteTrackMappingException(null, trackId, "Invalid sequence order: " + sequence);
+                }
+
+                parsedMappings.add(new TrackSequencePair(track, sequence));
+            }
+        }
+
+        return parsedMappings;
+    }
+
+    private UpdateAnalysis analyzeChanges(TalentRouteSnapshot route, List<TrackSequencePair> newMappings) {
+        // Build lookup map of existing mappings
+        Map<UUID, RouteTrackMapping> existingMap = route.getRouteTrackMappings()
+                .stream()
+                .collect(Collectors.toMap(
+                        mapping -> mapping.getGrowthTrack().getGrowthTrackId(),
+                        mapping -> mapping
+                ));
+
+        List<RouteTrackMapping> toAdd = new ArrayList<>();
+        List<RouteTrackMapping> toUpdate = new ArrayList<>();
+        int preserved = 0;
+
+        // Process each new mapping
+        for (TrackSequencePair newMapping : newMappings) {
+            UUID trackId = newMapping.getTrack().getGrowthTrackId();
+
+            if (existingMap.containsKey(trackId)) {
+                // TRACK EXISTS - Check if sequence changed
+                RouteTrackMapping existing = existingMap.get(trackId);
+                if (!existing.getSequenceOrder().equals(newMapping.getSequence())) {
+                    existing.setSequenceOrder(newMapping.getSequence());
+                    toUpdate.add(existing);
+                } else {
+                    preserved++; // No change needed
+                }
+                // Remove from map to track what remains
+                existingMap.remove(trackId);
+            } else {
+                // NEW TRACK - Create mapping
+                RouteTrackMapping newMappingEntity = RouteTrackMapping.builder()
+                        .talentRoute(route)
+                        .growthTrack(newMapping.getTrack())
+                        .sequenceOrder(newMapping.getSequence())
+                        .build();
+                toAdd.add(newMappingEntity);
+            }
+        }
+
+        // Remaining mappings in existingMap are preserved (not in new event)
+        preserved += existingMap.size();
+
+        return new UpdateAnalysis(toAdd, toUpdate, preserved);
+    }
+
+    private void applyRouteTrackMappingUpdates(TalentRouteSnapshot route, UpdateAnalysis analysis) {
+        // Add new mappings
+        if (!analysis.getToAdd().isEmpty()) {
+            route.getRouteTrackMappings().addAll(analysis.getToAdd());
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<TalentRouteSnapshot> findByTalentRouteId(UUID talentRouteId) {
+        log.debug("Finding route by talentRouteId: {}", talentRouteId);
+        return talentRouteSnapshotRepository.findByTalentRouteId(talentRouteId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean existsByTalentRouteId(UUID talentRouteId) {
+        log.debug("Checking if route exists by talentRouteId: {}", talentRouteId);
+        return talentRouteSnapshotRepository.existsByTalentRouteId(talentRouteId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<TalentRouteSnapshot> findByTalentRouteIdWithTrackMappings(UUID talentRouteId) {
+        log.debug("Finding route with track mappings by talentRouteId: {}", talentRouteId);
+        return talentRouteSnapshotRepository.findByTalentRouteIdWithTrackMappings(talentRouteId);
+    }
+
+    // Helper classes
+    @lombok.Data
+    @lombok.AllArgsConstructor
+    private static class TrackSequencePair {
+        private GrowthTrackSnapshot track;
+        private Integer sequence;
+    }
+
+    @lombok.Data
+    @lombok.AllArgsConstructor
+    private static class UpdateAnalysis {
+        private List<RouteTrackMapping> toAdd;
+        private List<RouteTrackMapping> toUpdate;
+        private int preserved;
+    }
+}


### PR DESCRIPTION
# 🚀   Pull Request: Integration of Kafka into the Roadmap Service
### 🎫   Jira Ticket
[:link:  SPRINT-2/VER-20: Consuming Kafka events and persist them into the database](https://amali-tech.atlassian.net/browse/VER-152)
---
## :white_check_mark:  Summary
This PR provides the integration for kafka events  `talentRoute.create`  in Roadmap service to consume the event and persist the information into the database.
---
## :pushpin:  Features  Added
- [x] `TalentRouteKafkaConsumer` to listen and consume events
- [x] Service logic to persist the TalentRoute with it's mapped growthTrack in the database
- [x] Smart update logic for talentRoute relationships
- [x] `GlobalExceptionHandler` for handling exceptions across the application
- [x] Proper mapping using `mapstruct` for performance optimization 
---
## 🚧  Next Task
- Implementing `learner progress` tracking logic