### PR TITLE
Feat: Create API to Fetch Skill RoadmapVER-117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-hibernate6</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
 		</dependency>

--- a/src/main/java/com/capstone/controller/GrowthTrackController.java
+++ b/src/main/java/com/capstone/controller/GrowthTrackController.java
@@ -1,0 +1,81 @@
+package com.capstone.controller;
+
+import com.capstone.dto.response.ApiResponseDto;
+import com.capstone.dto.response.GrowthTrackResponseDto;
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.service.GrowthTrackSnapshotService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/roadmap/growth-tracks")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Growth Track Management", description = "APIs for managing growth tracks")
+public class GrowthTrackController {
+
+    private final GrowthTrackSnapshotService growthTrackService;
+
+    @GetMapping
+    @Operation(summary = "Get all growth tracks (basic info)", description = "Retrieve paginated list of growth tracks with basic information")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<GrowthTrackResponseDto>>> findAllBasic(
+            @PageableDefault() Pageable pageable) {
+        log.info("Finding all growth tracks (basic), page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<GrowthTrackResponseDto> result = growthTrackService.findAllBasic(pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Growth tracks retrieved successfully"));
+    }
+
+    @GetMapping("/with-capsules")
+    @Operation(summary = "Get all growth tracks with capsule summaries", description = "Retrieve paginated list of growth tracks with their skill capsule summaries")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<GrowthTrackResponseDto>>> findAllWithCapsuleSummaries(
+            @PageableDefault() Pageable pageable) {
+        log.info("Finding all growth tracks with capsule summaries, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<GrowthTrackResponseDto> result = growthTrackService.findAllWithCapsuleSummaries(pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Growth tracks with capsule summaries retrieved successfully"));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Search growth tracks by name", description = "Search for growth tracks by track name (case-insensitive)")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<GrowthTrackResponseDto>>> searchByTrackName(
+            @Parameter(description = "Track name to search for", required = true) @RequestParam String name,
+            @PageableDefault() Pageable pageable) {
+        log.info("Searching growth tracks by name: '{}', page: {}, size: {}", name, pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<GrowthTrackResponseDto> result = growthTrackService.searchByTrackNameBasic(name, pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Growth tracks search completed successfully"));
+    }
+
+    @GetMapping("/{growthTrackId}")
+    @Operation(summary = "Get growth track by ID (basic info)", description = "Retrieve a specific growth track by its ID with basic information")
+    public ResponseEntity<ApiResponseDto<GrowthTrackResponseDto>> findByGrowthTrackIdBasic(
+            @Parameter(description = "Growth track ID", required = true) @PathVariable UUID growthTrackId) {
+        log.info("Finding growth track by ID (basic): {}", growthTrackId);
+
+        Optional<GrowthTrackResponseDto> result = growthTrackService.findByGrowthTrackIdBasic(growthTrackId);
+
+        return result.map(growthTrackResponseDto -> ResponseEntity.ok(ApiResponseDto.success(growthTrackResponseDto, "Growth track retrieved successfully"))).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{growthTrackId}/with-capsules")
+    @Operation(summary = "Get growth track by ID with capsule summaries", description = "Retrieve a specific growth track by its ID with skill capsule summaries")
+    public ResponseEntity<ApiResponseDto<GrowthTrackResponseDto>> findByGrowthTrackIdWithCapsuleSummaries(
+            @Parameter(description = "Growth track ID", required = true) @PathVariable UUID growthTrackId) {
+        log.info("Finding growth track by ID with capsule summaries: {}", growthTrackId);
+
+        Optional<GrowthTrackResponseDto> result = growthTrackService.findByGrowthTrackIdWithCapsuleSummaries(growthTrackId);
+
+        return result.map(growthTrackResponseDto -> ResponseEntity.ok(ApiResponseDto.success(growthTrackResponseDto, "Growth track with capsule summaries retrieved successfully"))).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/capstone/controller/SkillAtomController.java
+++ b/src/main/java/com/capstone/controller/SkillAtomController.java
@@ -1,0 +1,60 @@
+package com.capstone.controller;
+
+import com.capstone.dto.response.ApiResponseDto;
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.SkillAtomResponseDto;
+import com.capstone.service.SkillAtomSnapshotService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/roadmap/skill-atoms")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Skill Atom Management", description = "APIs for managing skill atoms")
+public class SkillAtomController {
+
+    private final SkillAtomSnapshotService skillAtomService;
+
+    @GetMapping
+    @Operation(summary = "Get all skill atoms (basic info)", description = "Retrieve paginated list of skill atoms with basic information")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<SkillAtomResponseDto>>> findAllBasic(
+            @PageableDefault() Pageable pageable) {
+        log.info("Finding all skill atoms (basic), page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<SkillAtomResponseDto> result = skillAtomService.findAllBasic(pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Skill atoms retrieved successfully"));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Search skill atoms by name", description = "Search for skill atoms by atom name (case-insensitive)")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<SkillAtomResponseDto>>> searchByName(
+            @Parameter(description = "Atom name to search for", required = true) @RequestParam String name,
+            @PageableDefault() Pageable pageable) {
+        log.info("Searching skill atoms by name: '{}', page: {}, size: {}", name, pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<SkillAtomResponseDto> result = skillAtomService.searchByNameBasic(name, pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Skill atoms search completed successfully"));
+    }
+
+    @GetMapping("/{skillAtomId}")
+    @Operation(summary = "Get skill atom by ID (basic info)", description = "Retrieve a specific skill atom by its ID with basic information")
+    public ResponseEntity<ApiResponseDto<SkillAtomResponseDto>> findBySkillAtomIdBasic(
+            @Parameter(description = "Skill atom ID", required = true) @PathVariable UUID skillAtomId) {
+        log.info("Finding skill atom by ID (basic): {}", skillAtomId);
+
+        Optional<SkillAtomResponseDto> result = skillAtomService.findBySkillAtomIdBasic(skillAtomId);
+
+        return result.map(skillAtomResponseDto -> ResponseEntity.ok(ApiResponseDto.success(skillAtomResponseDto, "Skill atom retrieved successfully"))).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/capstone/controller/SkillCapsuleController.java
+++ b/src/main/java/com/capstone/controller/SkillCapsuleController.java
@@ -1,0 +1,92 @@
+package com.capstone.controller;
+
+import com.capstone.dto.response.ApiResponseDto;
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.SkillCapsuleResponseDto;
+import com.capstone.service.SkillCapsuleSnapshotService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/roadmap/skill-capsules")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Skill Capsule Management", description = "APIs for managing skill capsules")
+public class SkillCapsuleController {
+
+    private final SkillCapsuleSnapshotService skillCapsuleService;
+
+    @GetMapping
+    @Operation(summary = "Get all skill capsules (basic info)", description = "Retrieve paginated list of skill capsules with basic information")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<SkillCapsuleResponseDto>>> findAllBasic(
+            @PageableDefault() Pageable pageable) {
+        log.info("Finding all skill capsules (basic), page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<SkillCapsuleResponseDto> result = skillCapsuleService.findAllBasic(pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Skill capsules retrieved successfully"));
+    }
+
+    @GetMapping("/with-atoms")
+    @Operation(summary = "Get all skill capsules with atom summaries", description = "Retrieve paginated list of skill capsules with their skill atom summaries")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<SkillCapsuleResponseDto>>> findAllWithAtomSummaries(
+            @PageableDefault() Pageable pageable) {
+        log.info("Finding all skill capsules with atom summaries, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<SkillCapsuleResponseDto> result = skillCapsuleService.findAllWithAtomSummaries(pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Skill capsules with atom summaries retrieved successfully"));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Search skill capsules by name", description = "Search for skill capsules by capsule name (case-insensitive)")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<SkillCapsuleResponseDto>>> searchByCapsuleName(
+            @Parameter(description = "Capsule name to search for", required = true) @RequestParam String name,
+            @PageableDefault() Pageable pageable) {
+        log.info("Searching skill capsules by name: '{}', page: {}, size: {}", name, pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<SkillCapsuleResponseDto> result = skillCapsuleService.searchByCapsuleNameBasic(name, pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Skill capsules search completed successfully"));
+    }
+
+    @GetMapping("/by-difficulty/{difficultyLevel}")
+    @Operation(summary = "Get skill capsules by difficulty level", description = "Retrieve paginated list of skill capsules by difficulty level")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<SkillCapsuleResponseDto>>> findByDifficultyLevel(
+            @Parameter(description = "Difficulty level", required = true) @PathVariable String difficultyLevel,
+            @PageableDefault() Pageable pageable) {
+        log.info("Finding skill capsules by difficulty level: '{}', page: {}, size: {}", difficultyLevel, pageable.getPageNumber(), pageable.getPageSize());
+
+        PaginatedResponseDto<SkillCapsuleResponseDto> result = skillCapsuleService.findByDifficultyLevelBasic(difficultyLevel, pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Skill capsules by difficulty level retrieved successfully"));
+    }
+
+    @GetMapping("/{skillCapsuleId}")
+    @Operation(summary = "Get skill capsule by ID (basic info)", description = "Retrieve a specific skill capsule by its ID with basic information")
+    public ResponseEntity<ApiResponseDto<SkillCapsuleResponseDto>> findBySkillCapsuleIdBasic(
+            @Parameter(description = "Skill capsule ID", required = true) @PathVariable UUID skillCapsuleId) {
+        log.info("Finding skill capsule by ID (basic): {}", skillCapsuleId);
+
+        Optional<SkillCapsuleResponseDto> result = skillCapsuleService.findBySkillCapsuleIdBasic(skillCapsuleId);
+
+        return result.map(skillCapsuleResponseDto -> ResponseEntity.ok(ApiResponseDto.success(skillCapsuleResponseDto, "Skill capsule retrieved successfully"))).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{skillCapsuleId}/with-atoms")
+    @Operation(summary = "Get skill capsule by ID with atom summaries", description = "Retrieve a specific skill capsule by its ID with skill atom summaries")
+    public ResponseEntity<ApiResponseDto<SkillCapsuleResponseDto>> findBySkillCapsuleIdWithAtomSummaries(
+            @Parameter(description = "Skill capsule ID", required = true) @PathVariable UUID skillCapsuleId) {
+        log.info("Finding skill capsule by ID with atom summaries: {}", skillCapsuleId);
+
+        Optional<SkillCapsuleResponseDto> result = skillCapsuleService.findBySkillCapsuleIdWithAtomSummaries(skillCapsuleId);
+
+        return result.map(skillCapsuleResponseDto -> ResponseEntity.ok(ApiResponseDto.success(skillCapsuleResponseDto, "Skill capsule with atom summaries retrieved successfully"))).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/capstone/controller/TalentRouteController.java
+++ b/src/main/java/com/capstone/controller/TalentRouteController.java
@@ -1,0 +1,113 @@
+package com.capstone.controller;
+
+import com.capstone.dto.response.ApiResponseDto;
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.TalentRouteResponseDto;
+import com.capstone.service.TalentRouteSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/roadmap/talent-routes")
+@RequiredArgsConstructor
+@Slf4j
+public class TalentRouteController {
+
+    private final TalentRouteSnapshotService talentRouteSnapshotService;
+
+    /**
+     * Get all talent routes (basic info only)
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentRouteResponseDto>>> getAllTalentRoutes(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "routeName") String sort,
+            @RequestParam(defaultValue = "asc") String direction) {
+
+        log.info("Fetching talent routes: page={}, size={}, sort={}, direction={}",
+            page, size, sort, direction);
+
+        Sort.Direction sortDirection = direction.equalsIgnoreCase("desc") ?
+            Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+
+        PaginatedResponseDto<TalentRouteResponseDto> result = talentRouteSnapshotService.findAllBasic(pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Talent routes retrieved successfully"));
+    }
+
+    /**
+     * Get all talent routes with their growth track summaries
+     */
+    @GetMapping("/with-tracks")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentRouteResponseDto>>> getAllTalentRoutesWithTracks(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "routeName") String sort,
+            @RequestParam(defaultValue = "asc") String direction) {
+
+        log.info("Fetching talent routes with tracks: page={}, size={}, sort={}, direction={}",
+            page, size, sort, direction);
+
+        Sort.Direction sortDirection = direction.equalsIgnoreCase("desc") ?
+            Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+
+        PaginatedResponseDto<TalentRouteResponseDto> result = talentRouteSnapshotService.findAllWithTrackSummaries(pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Talent routes with tracks retrieved successfully"));
+    }
+
+    /**
+     * Search talent routes by name
+     */
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentRouteResponseDto>>> searchTalentRoutes(
+            @RequestParam String name,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "routeName") String sort,
+            @RequestParam(defaultValue = "asc") String direction) {
+
+        log.info("Searching talent routes by name '{}': page={}, size={}, sort={}, direction={}",
+            name, page, size, sort, direction);
+
+        Sort.Direction sortDirection = direction.equalsIgnoreCase("desc") ?
+            Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sortDirection, sort));
+
+        PaginatedResponseDto<TalentRouteResponseDto> result = talentRouteSnapshotService.searchByRouteNameBasic(name, pageable);
+        return ResponseEntity.ok(ApiResponseDto.success(result, "Search results retrieved successfully"));
+    }
+
+    /**
+     * Get single talent route by ID (basic info only)
+     */
+    @GetMapping("/{routeId}")
+    public ResponseEntity<ApiResponseDto<TalentRouteResponseDto>> getTalentRouteById(@PathVariable UUID routeId) {
+        log.info("Fetching talent route by ID: {}", routeId);
+
+        Optional<TalentRouteResponseDto> route = talentRouteSnapshotService.findByTalentRouteIdBasic(routeId);
+        return route.map(r -> ResponseEntity.ok(ApiResponseDto.success(r, "Talent route retrieved successfully")))
+                   .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Get single talent route with its growth track summaries
+     */
+    @GetMapping("/{routeId}/with-tracks")
+    public ResponseEntity<ApiResponseDto<TalentRouteResponseDto>> getTalentRouteByIdWithTracks(@PathVariable UUID routeId) {
+        log.info("Fetching talent route with tracks by ID: {}", routeId);
+
+        Optional<TalentRouteResponseDto> route = talentRouteSnapshotService.findByTalentRouteIdWithTrackSummaries(routeId);
+        return route.map(r -> ResponseEntity.ok(ApiResponseDto.success(r, "Talent route with tracks retrieved successfully")))
+                   .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/capstone/dto/response/GrowthTrackResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/GrowthTrackResponseDto.java
@@ -1,0 +1,27 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GrowthTrackResponseDto {
+    private UUID id;
+    private UUID growthTrackId;
+    private String trackName;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Integer totalCapsules;
+    private List<SkillCapsuleSummaryDto> capsules;
+}

--- a/src/main/java/com/capstone/dto/response/GrowthTrackSummaryDto.java
+++ b/src/main/java/com/capstone/dto/response/GrowthTrackSummaryDto.java
@@ -1,0 +1,23 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GrowthTrackSummaryDto {
+    private UUID id;
+    private UUID growthTrackId;
+    private String trackName;
+    private String description;
+    private Integer sequenceOrder;
+    private Integer totalCapsules;
+}

--- a/src/main/java/com/capstone/dto/response/PaginatedResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/PaginatedResponseDto.java
@@ -1,0 +1,20 @@
+package com.capstone.dto.response;
+
+import com.capstone.model.PaginationMetadata;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PaginatedResponseDto<T> {
+    private List<T> items;
+    private PaginationMetadata pagination;
+}

--- a/src/main/java/com/capstone/dto/response/SkillAtomResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/SkillAtomResponseDto.java
@@ -1,0 +1,26 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SkillAtomResponseDto {
+    private UUID id;
+    private UUID skillAtomId;
+    private String name;
+    private String description;
+    private Integer moodleModuleId;
+    private Integer moodlePageId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/capstone/dto/response/SkillAtomSummaryDto.java
+++ b/src/main/java/com/capstone/dto/response/SkillAtomSummaryDto.java
@@ -1,0 +1,25 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SkillAtomSummaryDto {
+    private UUID id;
+    private UUID skillAtomId;
+    private String atomName;
+    private String description;
+    private String atomType;
+    private String difficultyLevel;
+    private Integer sequenceOrder;
+    private Integer estimatedMinutes;
+}

--- a/src/main/java/com/capstone/dto/response/SkillCapsuleResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/SkillCapsuleResponseDto.java
@@ -1,0 +1,30 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SkillCapsuleResponseDto {
+    private UUID id;
+    private UUID skillCapsuleId;
+    private String capsuleName;
+    private String description;
+    private String difficultyLevel;
+    private String proficiencyLevel;
+    private Integer moodleCourseId;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Integer totalAtoms;
+    private List<SkillAtomSummaryDto> atoms;
+}

--- a/src/main/java/com/capstone/dto/response/SkillCapsuleSummaryDto.java
+++ b/src/main/java/com/capstone/dto/response/SkillCapsuleSummaryDto.java
@@ -1,0 +1,25 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SkillCapsuleSummaryDto {
+    private UUID id;
+    private UUID skillCapsuleId;
+    private String capsuleName;
+    private String description;
+    private String difficultyLevel;
+    private String proficiencyLevel;
+    private Integer sequenceOrder;
+    private Integer totalAtoms;
+}

--- a/src/main/java/com/capstone/dto/response/TalentRouteResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/TalentRouteResponseDto.java
@@ -1,0 +1,27 @@
+package com.capstone.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TalentRouteResponseDto {
+    private UUID id;
+    private UUID talentRouteId;
+    private String routeName;
+    private String description;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Integer totalTracks;
+    private List<GrowthTrackSummaryDto> tracks;
+}

--- a/src/main/java/com/capstone/mapper/GrowthTrackMapper.java
+++ b/src/main/java/com/capstone/mapper/GrowthTrackMapper.java
@@ -1,0 +1,33 @@
+package com.capstone.mapper;
+
+import com.capstone.dto.response.GrowthTrackResponseDto;
+import com.capstone.dto.response.SkillCapsuleSummaryDto;
+import com.capstone.model.GrowthTrackSnapshot;
+import com.capstone.model.TrackCapsuleMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface GrowthTrackMapper {
+
+    @Mapping(target = "totalCapsules", expression = "java(entity.getTrackCapsuleMappings().size())")
+    @Mapping(target = "capsules", ignore = true)
+    GrowthTrackResponseDto toBasicResponseDto(GrowthTrackSnapshot entity);
+
+    @Mapping(target = "totalCapsules", expression = "java(entity.getTrackCapsuleMappings().size())")
+    @Mapping(target = "capsules", source = "trackCapsuleMappings")
+    GrowthTrackResponseDto toResponseDtoWithCapsules(GrowthTrackSnapshot entity);
+
+    @Mapping(target = "totalAtoms", expression = "java(mapping.getSkillCapsule().getCapsuleAtomMappings().size())")
+    @Mapping(source = "skillCapsule.id", target = "id")
+    @Mapping(source = "skillCapsule.skillCapsuleId", target = "skillCapsuleId")
+    @Mapping(source = "skillCapsule.capsuleName", target = "capsuleName")
+    @Mapping(source = "skillCapsule.description", target = "description")
+    @Mapping(source = "skillCapsule.difficultyLevel", target = "difficultyLevel")
+    @Mapping(source = "skillCapsule.proficiencyLevel", target = "proficiencyLevel")
+    SkillCapsuleSummaryDto toSkillCapsuleSummaryDto(TrackCapsuleMapping mapping);
+
+    List<SkillCapsuleSummaryDto> toSkillCapsuleSummaryDtoList(List<TrackCapsuleMapping> mappings);
+}

--- a/src/main/java/com/capstone/mapper/SkillAtomMapper.java
+++ b/src/main/java/com/capstone/mapper/SkillAtomMapper.java
@@ -1,0 +1,11 @@
+package com.capstone.mapper;
+
+import com.capstone.dto.response.SkillAtomResponseDto;
+import com.capstone.model.SkillAtomSnapshot;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface SkillAtomMapper {
+
+    SkillAtomResponseDto toResponseDto(SkillAtomSnapshot entity);
+}

--- a/src/main/java/com/capstone/mapper/SkillCapsuleMapper.java
+++ b/src/main/java/com/capstone/mapper/SkillCapsuleMapper.java
@@ -1,0 +1,33 @@
+package com.capstone.mapper;
+
+import com.capstone.dto.response.SkillAtomSummaryDto;
+import com.capstone.dto.response.SkillCapsuleResponseDto;
+import com.capstone.model.CapsuleAtomMapping;
+import com.capstone.model.SkillCapsuleSnapshot;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface SkillCapsuleMapper {
+
+    @Mapping(target = "totalAtoms", expression = "java(entity.getCapsuleAtomMappings().size())")
+    @Mapping(target = "atoms", ignore = true)
+    SkillCapsuleResponseDto toBasicResponseDto(SkillCapsuleSnapshot entity);
+
+    @Mapping(target = "totalAtoms", expression = "java(entity.getCapsuleAtomMappings().size())")
+    @Mapping(target = "atoms", source = "capsuleAtomMappings")
+    SkillCapsuleResponseDto toResponseDtoWithAtoms(SkillCapsuleSnapshot entity);
+
+    @Mapping(source = "skillAtom.id", target = "id")
+    @Mapping(source = "skillAtom.skillAtomId", target = "skillAtomId")
+    @Mapping(source = "skillAtom.name", target = "atomName")
+    @Mapping(source = "skillAtom.description", target = "description")
+    @Mapping(target = "atomType", ignore = true)
+    @Mapping(target = "difficultyLevel", ignore = true)
+    @Mapping(target = "estimatedMinutes", ignore = true)
+    SkillAtomSummaryDto toSkillAtomSummaryDto(CapsuleAtomMapping mapping);
+
+    List<SkillAtomSummaryDto> toSkillAtomSummaryDtoList(List<CapsuleAtomMapping> mappings);
+}

--- a/src/main/java/com/capstone/mapper/TalentRouteMapper.java
+++ b/src/main/java/com/capstone/mapper/TalentRouteMapper.java
@@ -1,0 +1,31 @@
+package com.capstone.mapper;
+
+import com.capstone.dto.response.GrowthTrackSummaryDto;
+import com.capstone.dto.response.TalentRouteResponseDto;
+import com.capstone.model.RouteTrackMapping;
+import com.capstone.model.TalentRouteSnapshot;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface TalentRouteMapper {
+
+    @Mapping(target = "totalTracks", expression = "java(entity.getRouteTrackMappings().size())")
+    @Mapping(target = "tracks", ignore = true)
+    TalentRouteResponseDto toBasicResponseDto(TalentRouteSnapshot entity);
+
+    @Mapping(target = "totalTracks", expression = "java(entity.getRouteTrackMappings().size())")
+    @Mapping(target = "tracks", source = "routeTrackMappings")
+    TalentRouteResponseDto toResponseDtoWithTracks(TalentRouteSnapshot entity);
+
+    @Mapping(target = "totalCapsules", expression = "java(mapping.getGrowthTrack().getTrackCapsuleMappings().size())")
+    @Mapping(source = "growthTrack.id", target = "id")
+    @Mapping(source = "growthTrack.growthTrackId", target = "growthTrackId")
+    @Mapping(source = "growthTrack.trackName", target = "trackName")
+    @Mapping(source = "growthTrack.description", target = "description")
+    GrowthTrackSummaryDto toGrowthTrackSummaryDto(RouteTrackMapping mapping);
+
+    List<GrowthTrackSummaryDto> toGrowthTrackSummaryDtoList(List<RouteTrackMapping> mappings);
+}

--- a/src/main/java/com/capstone/model/CapsuleAtomMapping.java
+++ b/src/main/java/com/capstone/model/CapsuleAtomMapping.java
@@ -1,5 +1,6 @@
 package com.capstone.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Min;
@@ -48,6 +49,7 @@ public class CapsuleAtomMapping {
             nullable = false,
             foreignKey = @ForeignKey(name = "fk_capsule_mapping_capsule")
     )
+    @JsonIgnore
     private SkillCapsuleSnapshot skillCapsule;
 
     // Many-to-One relationship with SkillAtomSnapshot

--- a/src/main/java/com/capstone/model/PaginationMetadata.java
+++ b/src/main/java/com/capstone/model/PaginationMetadata.java
@@ -1,0 +1,20 @@
+package com.capstone.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaginationMetadata {
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}
+

--- a/src/main/java/com/capstone/model/RouteTrackMapping.java
+++ b/src/main/java/com/capstone/model/RouteTrackMapping.java
@@ -1,5 +1,6 @@
 package com.capstone.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Min;
@@ -47,6 +48,7 @@ public class RouteTrackMapping {
             nullable = false,
             foreignKey = @ForeignKey(name = "fk_route_mapping_route")
     )
+    @JsonIgnore
     private TalentRouteSnapshot talentRoute;
 
     @NotNull(message = "Growth track is required")

--- a/src/main/java/com/capstone/model/TrackCapsuleMapping.java
+++ b/src/main/java/com/capstone/model/TrackCapsuleMapping.java
@@ -1,5 +1,6 @@
 package com.capstone.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Min;
@@ -47,6 +48,7 @@ public class TrackCapsuleMapping {
             nullable = false,
             foreignKey = @ForeignKey(name = "fk_track_mapping_track")
     )
+    @JsonIgnore
     private GrowthTrackSnapshot growthTrack;
 
     @NotNull(message = "Skill capsule is required")

--- a/src/main/java/com/capstone/repository/GrowthTrackSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/GrowthTrackSnapshotRepository.java
@@ -1,6 +1,8 @@
 package com.capstone.repository;
 
 import com.capstone.model.GrowthTrackSnapshot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,7 @@ import java.util.UUID;
 @Repository
 public interface GrowthTrackSnapshotRepository extends JpaRepository<GrowthTrackSnapshot, UUID> {
 
+    // ===== EXISTING METHODS =====
     Optional<GrowthTrackSnapshot> findByGrowthTrackId(UUID growthTrackId);
 
     boolean existsByGrowthTrackId(UUID growthTrackId);
@@ -23,4 +26,19 @@ public interface GrowthTrackSnapshotRepository extends JpaRepository<GrowthTrack
             "ORDER BY tcm.sequenceOrder ASC")
     Optional<GrowthTrackSnapshot> findByGrowthTrackIdWithCapsuleMappings(@Param("growthTrackId") UUID growthTrackId);
 
+    // ===== NEW PAGINATION METHODS =====
+    @Query("SELECT DISTINCT gt FROM GrowthTrackSnapshot gt " +
+            "LEFT JOIN FETCH gt.trackCapsuleMappings tcm " +
+            "LEFT JOIN FETCH tcm.skillCapsule")
+    Page<GrowthTrackSnapshot> findAllWithCapsuleMappings(Pageable pageable);
+
+    @Query("SELECT gt FROM GrowthTrackSnapshot gt " +
+            "WHERE LOWER(gt.trackName) LIKE LOWER(CONCAT('%', :trackName, '%'))")
+    Page<GrowthTrackSnapshot> findByTrackNameContainingIgnoreCase(@Param("trackName") String trackName, Pageable pageable);
+
+    @Query("SELECT DISTINCT gt FROM GrowthTrackSnapshot gt " +
+            "INNER JOIN RouteTrackMapping rtm ON rtm.growthTrack.id = gt.id " +
+            "WHERE rtm.talentRoute.talentRouteId = :talentRouteId " +
+            "ORDER BY rtm.sequenceOrder ASC")
+    Page<GrowthTrackSnapshot> findByTalentRouteId(@Param("talentRouteId") UUID talentRouteId, Pageable pageable);
 }

--- a/src/main/java/com/capstone/repository/SkillAtomSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/SkillAtomSnapshotRepository.java
@@ -1,8 +1,11 @@
 package com.capstone.repository;
 
-
 import com.capstone.model.SkillAtomSnapshot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,6 +13,19 @@ import java.util.UUID;
 
 @Repository
 public interface SkillAtomSnapshotRepository extends JpaRepository<SkillAtomSnapshot, UUID> {
+
+    // ===== EXISTING METHODS =====
     Optional<SkillAtomSnapshot> findBySkillAtomId(UUID skillAtomId);
     boolean existsBySkillAtomId(UUID skillAtomId);
+
+    // ===== NEW PAGINATION METHODS =====
+    @Query("SELECT a FROM SkillAtomSnapshot a " +
+            "WHERE LOWER(a.name) LIKE LOWER(CONCAT('%', :name, '%'))")
+    Page<SkillAtomSnapshot> findByNameContainingIgnoreCase(@Param("name") String name, Pageable pageable);
+
+    @Query("SELECT DISTINCT a FROM SkillAtomSnapshot a " +
+            "INNER JOIN CapsuleAtomMapping cam ON cam.skillAtom.id = a.id " +
+            "WHERE cam.skillCapsule.skillCapsuleId = :skillCapsuleId " +
+            "ORDER BY cam.sequenceOrder ASC")
+    Page<SkillAtomSnapshot> findBySkillCapsuleId(@Param("skillCapsuleId") UUID skillCapsuleId, Pageable pageable);
 }

--- a/src/main/java/com/capstone/repository/SkillCapsuleSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/SkillCapsuleSnapshotRepository.java
@@ -1,6 +1,8 @@
 package com.capstone.repository;
 
 import com.capstone.model.SkillCapsuleSnapshot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,7 @@ import java.util.UUID;
 @Repository
 public interface SkillCapsuleSnapshotRepository extends JpaRepository<SkillCapsuleSnapshot, UUID> {
 
+    // ===== EXISTING METHODS =====
     Optional<SkillCapsuleSnapshot> findBySkillCapsuleId(UUID skillCapsuleId);
     boolean existsBySkillCapsuleId(UUID skillCapsuleId);
 
@@ -21,4 +24,24 @@ public interface SkillCapsuleSnapshotRepository extends JpaRepository<SkillCapsu
             "WHERE c.skillCapsuleId = :skillCapsuleId " +
             "ORDER BY cam.sequenceOrder ASC")
     Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(@Param("skillCapsuleId") UUID skillCapsuleId);
+
+    // ===== NEW PAGINATION METHODS =====
+    @Query("SELECT DISTINCT c FROM SkillCapsuleSnapshot c " +
+            "LEFT JOIN FETCH c.capsuleAtomMappings cam " +
+            "LEFT JOIN FETCH cam.skillAtom")
+    Page<SkillCapsuleSnapshot> findAllWithAtomMappings(Pageable pageable);
+
+    @Query("SELECT c FROM SkillCapsuleSnapshot c " +
+            "WHERE LOWER(c.capsuleName) LIKE LOWER(CONCAT('%', :capsuleName, '%'))")
+    Page<SkillCapsuleSnapshot> findByCapsuleNameContainingIgnoreCase(@Param("capsuleName") String capsuleName, Pageable pageable);
+
+    @Query("SELECT c FROM SkillCapsuleSnapshot c " +
+            "WHERE LOWER(c.difficultyLevel) = LOWER(:difficultyLevel)")
+    Page<SkillCapsuleSnapshot> findByDifficultyLevel(@Param("difficultyLevel") String difficultyLevel, Pageable pageable);
+
+    @Query("SELECT DISTINCT c FROM SkillCapsuleSnapshot c " +
+            "INNER JOIN TrackCapsuleMapping tcm ON tcm.skillCapsule.id = c.id " +
+            "WHERE tcm.growthTrack.growthTrackId = :growthTrackId " +
+            "ORDER BY tcm.sequenceOrder ASC")
+    Page<SkillCapsuleSnapshot> findByGrowthTrackId(@Param("growthTrackId") UUID growthTrackId, Pageable pageable);
 }

--- a/src/main/java/com/capstone/repository/TalentRouteSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/TalentRouteSnapshotRepository.java
@@ -1,6 +1,8 @@
 package com.capstone.repository;
 
 import com.capstone.model.TalentRouteSnapshot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,4 +24,13 @@ public interface TalentRouteSnapshotRepository extends JpaRepository<TalentRoute
             "WHERE tr.talentRouteId = :talentRouteId " +
             "ORDER BY rtm.sequenceOrder ASC")
     Optional<TalentRouteSnapshot> findByTalentRouteIdWithTrackMappings(@Param("talentRouteId") UUID talentRouteId);
+
+    @Query("SELECT DISTINCT tr FROM TalentRouteSnapshot tr " +
+            "LEFT JOIN FETCH tr.routeTrackMappings rtm " +
+            "LEFT JOIN FETCH rtm.growthTrack")
+    Page<TalentRouteSnapshot> findAllWithTrackMappings(Pageable pageable);
+
+    @Query("SELECT tr FROM TalentRouteSnapshot tr " +
+            "WHERE LOWER(tr.routeName) LIKE LOWER(CONCAT('%', :routeName, '%'))")
+    Page<TalentRouteSnapshot> findByRouteNameContainingIgnoreCase(@Param("routeName") String routeName, Pageable pageable);
 }

--- a/src/main/java/com/capstone/service/GrowthTrackSnapshotService.java
+++ b/src/main/java/com/capstone/service/GrowthTrackSnapshotService.java
@@ -1,7 +1,10 @@
 package com.capstone.service;
 
+import com.capstone.dto.response.GrowthTrackResponseDto;
+import com.capstone.dto.response.PaginatedResponseDto;
 import com.capstone.model.GrowthTrackSnapshot;
 import org.common.event.GrowthTrackEvent;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
@@ -16,4 +19,11 @@ public interface GrowthTrackSnapshotService {
     Optional<GrowthTrackSnapshot> findByGrowthTrackId(UUID growthTrackId);
     boolean existsByGrowthTrackId(UUID growthTrackId);
     Optional<GrowthTrackSnapshot> findByGrowthTrackIdWithCapsuleMappings(UUID growthTrackId);
+
+
+    PaginatedResponseDto<GrowthTrackResponseDto> findAllBasic(Pageable pageable);
+    PaginatedResponseDto<GrowthTrackResponseDto> findAllWithCapsuleSummaries(Pageable pageable);
+    PaginatedResponseDto<GrowthTrackResponseDto> searchByTrackNameBasic(String trackName, Pageable pageable);
+    Optional<GrowthTrackResponseDto> findByGrowthTrackIdBasic(UUID growthTrackId);
+    Optional<GrowthTrackResponseDto> findByGrowthTrackIdWithCapsuleSummaries(UUID growthTrackId);
 }

--- a/src/main/java/com/capstone/service/SkillAtomSnapshotService.java
+++ b/src/main/java/com/capstone/service/SkillAtomSnapshotService.java
@@ -1,15 +1,25 @@
 package com.capstone.service;
 
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.SkillAtomResponseDto;
 import com.capstone.model.SkillAtomSnapshot;
 import org.common.event.SkillAtomEvent;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface SkillAtomSnapshotService {
+
+    // ===== EXISTING KAFKA/PROCESSING METHODS =====
     SkillAtomSnapshot processSkillAtomEvent(SkillAtomEvent event);
     SkillAtomSnapshot createSkillAtom(SkillAtomEvent event);
     SkillAtomSnapshot updateSkillAtom(SkillAtomSnapshot existingSkillAtom, SkillAtomEvent event);
     Optional<SkillAtomSnapshot> findBySkillAtomId(UUID skillAtomId);
     boolean existsBySkillAtomId(UUID skillAtomId);
+
+    // ===== NEW CLEAN DTO-BASED METHODS =====
+    PaginatedResponseDto<SkillAtomResponseDto> findAllBasic(Pageable pageable);
+    PaginatedResponseDto<SkillAtomResponseDto> searchByNameBasic(String name, Pageable pageable);
+    Optional<SkillAtomResponseDto> findBySkillAtomIdBasic(UUID skillAtomId);
 }

--- a/src/main/java/com/capstone/service/SkillCapsuleSnapshotService.java
+++ b/src/main/java/com/capstone/service/SkillCapsuleSnapshotService.java
@@ -1,7 +1,10 @@
 package com.capstone.service;
 
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.SkillCapsuleResponseDto;
 import com.capstone.model.SkillCapsuleSnapshot;
 import org.common.event.SkillCapsuleEvent;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
@@ -10,6 +13,7 @@ import java.util.UUID;
 
 public interface SkillCapsuleSnapshotService {
 
+    // ===== EXISTING KAFKA/PROCESSING METHODS =====
     SkillCapsuleSnapshot processSkillCapsuleEvent(SkillCapsuleEvent event);
     SkillCapsuleSnapshot createSkillCapsule(SkillCapsuleEvent event);
     SkillCapsuleSnapshot updateSkillCapsule(SkillCapsuleSnapshot existingCapsule, SkillCapsuleEvent event);
@@ -17,4 +21,12 @@ public interface SkillCapsuleSnapshotService {
     Optional<SkillCapsuleSnapshot> findBySkillCapsuleId(UUID skillCapsuleId);
     boolean existsBySkillCapsuleId(UUID skillCapsuleId);
     Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(UUID skillCapsuleId);
+
+    // ===== NEW CLEAN DTO-BASED METHODS =====
+    PaginatedResponseDto<SkillCapsuleResponseDto> findAllBasic(Pageable pageable);
+    PaginatedResponseDto<SkillCapsuleResponseDto> findAllWithAtomSummaries(Pageable pageable);
+    PaginatedResponseDto<SkillCapsuleResponseDto> searchByCapsuleNameBasic(String capsuleName, Pageable pageable);
+    PaginatedResponseDto<SkillCapsuleResponseDto> findByDifficultyLevelBasic(String difficultyLevel, Pageable pageable);
+    Optional<SkillCapsuleResponseDto> findBySkillCapsuleIdBasic(UUID skillCapsuleId);
+    Optional<SkillCapsuleResponseDto> findBySkillCapsuleIdWithAtomSummaries(UUID skillCapsuleId);
 }

--- a/src/main/java/com/capstone/service/TalentRouteSnapshotService.java
+++ b/src/main/java/com/capstone/service/TalentRouteSnapshotService.java
@@ -1,7 +1,10 @@
 package com.capstone.service;
 
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.TalentRouteResponseDto;
 import com.capstone.model.TalentRouteSnapshot;
 import org.common.event.TalentRouteEvent;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Map;
@@ -9,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface TalentRouteSnapshotService {
+    // ===== EXISTING KAFKA/PROCESSING METHODS =====
     TalentRouteSnapshot processTalentRouteEvent(TalentRouteEvent event);
     TalentRouteSnapshot createTalentRoute(TalentRouteEvent event);
     TalentRouteSnapshot updateTalentRoute(TalentRouteSnapshot existingRoute, TalentRouteEvent event);
@@ -16,4 +20,16 @@ public interface TalentRouteSnapshotService {
     Optional<TalentRouteSnapshot> findByTalentRouteId(UUID talentRouteId);
     boolean existsByTalentRouteId(UUID talentRouteId);
     Optional<TalentRouteSnapshot> findByTalentRouteIdWithTrackMappings(UUID talentRouteId);
+
+    // ===== OLD ENTITY-BASED METHODS (TO BE DEPRECATED) =====
+    PaginatedResponseDto<TalentRouteSnapshot> findAll(Pageable pageable);
+    PaginatedResponseDto<TalentRouteSnapshot> findAllWithTrackMappings(Pageable pageable);
+    PaginatedResponseDto<TalentRouteSnapshot> searchByRouteName(String routeName, Pageable pageable);
+
+    // ===== NEW CLEAN DTO-BASED METHODS =====
+    PaginatedResponseDto<TalentRouteResponseDto> findAllBasic(Pageable pageable);
+    PaginatedResponseDto<TalentRouteResponseDto> findAllWithTrackSummaries(Pageable pageable);
+    PaginatedResponseDto<TalentRouteResponseDto> searchByRouteNameBasic(String routeName, Pageable pageable);
+    Optional<TalentRouteResponseDto> findByTalentRouteIdBasic(UUID talentRouteId);
+    Optional<TalentRouteResponseDto> findByTalentRouteIdWithTrackSummaries(UUID talentRouteId);
 }

--- a/src/main/java/com/capstone/service/impl/GrowthTrackSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/GrowthTrackSnapshotServiceImpl.java
@@ -1,17 +1,23 @@
 package com.capstone.service.impl;
 
+import com.capstone.dto.response.GrowthTrackResponseDto;
+import com.capstone.dto.response.PaginatedResponseDto;
 import com.capstone.exception.*;
 import com.capstone.mapper.GrowthTrackEventMapper;
+import com.capstone.mapper.GrowthTrackMapper;
 import com.capstone.model.GrowthTrackSnapshot;
 import com.capstone.model.SkillCapsuleSnapshot;
 import com.capstone.model.TrackCapsuleMapping;
 import com.capstone.repository.GrowthTrackSnapshotRepository;
 import com.capstone.service.GrowthTrackSnapshotService;
 import com.capstone.service.SkillCapsuleSnapshotService;
+import com.capstone.util.PaginationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.common.event.GrowthTrackEvent;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +32,7 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
 
     private final GrowthTrackSnapshotRepository growthTrackSnapshotRepository;
     private final GrowthTrackEventMapper growthTrackEventMapper;
+    private final GrowthTrackMapper growthTrackMapper;
     private final SkillCapsuleSnapshotService skillCapsuleSnapshotService;
 
     @Override
@@ -230,6 +237,49 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
     public Optional<GrowthTrackSnapshot> findByGrowthTrackIdWithCapsuleMappings(UUID growthTrackId) {
         log.debug("Finding track with capsule mappings by growthTrackId: {}", growthTrackId);
         return growthTrackSnapshotRepository.findByGrowthTrackIdWithCapsuleMappings(growthTrackId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<GrowthTrackResponseDto> findAllBasic(Pageable pageable) {
+        log.debug("Finding all growth tracks with basic info, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        Page<GrowthTrackSnapshot> pageData = growthTrackSnapshotRepository.findAll(pageable);
+        Page<GrowthTrackResponseDto> dtoPage = pageData.map(growthTrackMapper::toBasicResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<GrowthTrackResponseDto> findAllWithCapsuleSummaries(Pageable pageable) {
+        log.debug("Finding all growth tracks with capsule summaries, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        Page<GrowthTrackSnapshot> pageData = growthTrackSnapshotRepository.findAllWithCapsuleMappings(pageable);
+        Page<GrowthTrackResponseDto> dtoPage = pageData.map(growthTrackMapper::toResponseDtoWithCapsules);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<GrowthTrackResponseDto> searchByTrackNameBasic(String trackName, Pageable pageable) {
+        log.debug("Searching growth tracks by name: '{}', page: {}, size: {}", trackName, pageable.getPageNumber(), pageable.getPageSize());
+        Page<GrowthTrackSnapshot> pageData = growthTrackSnapshotRepository.findByTrackNameContainingIgnoreCase(trackName, pageable);
+        Page<GrowthTrackResponseDto> dtoPage = pageData.map(growthTrackMapper::toBasicResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<GrowthTrackResponseDto> findByGrowthTrackIdBasic(UUID growthTrackId) {
+        log.debug("Finding growth track by ID with basic info: {}", growthTrackId);
+        return growthTrackSnapshotRepository.findByGrowthTrackId(growthTrackId)
+                .map(growthTrackMapper::toBasicResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<GrowthTrackResponseDto> findByGrowthTrackIdWithCapsuleSummaries(UUID growthTrackId) {
+        log.debug("Finding growth track by ID with capsule summaries: {}", growthTrackId);
+        return growthTrackSnapshotRepository.findByGrowthTrackIdWithCapsuleMappings(growthTrackId)
+                .map(growthTrackMapper::toResponseDtoWithCapsules);
     }
 
     // Helper classes

--- a/src/main/java/com/capstone/service/impl/SkillAtomSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/SkillAtomSnapshotServiceImpl.java
@@ -1,14 +1,20 @@
 package com.capstone.service.impl;
 
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.SkillAtomResponseDto;
 import com.capstone.exception.SkillAtomProcessingException;
 import com.capstone.mapper.SkillAtomEventMapper;
+import com.capstone.mapper.SkillAtomMapper;
 import com.capstone.model.SkillAtomSnapshot;
 import com.capstone.repository.SkillAtomSnapshotRepository;
 import com.capstone.service.SkillAtomSnapshotService;
+import com.capstone.util.PaginationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.common.event.SkillAtomEvent;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +29,7 @@ public class SkillAtomSnapshotServiceImpl implements SkillAtomSnapshotService {
 
     private final SkillAtomSnapshotRepository skillAtomSnapshotRepository;
     private final SkillAtomEventMapper skillAtomEventMapper;
+    private final SkillAtomMapper skillAtomMapper;
 
     @Override
     public SkillAtomSnapshot processSkillAtomEvent(SkillAtomEvent event) {
@@ -95,5 +102,31 @@ public class SkillAtomSnapshotServiceImpl implements SkillAtomSnapshotService {
     public boolean existsBySkillAtomId(UUID skillAtomId) {
         log.debug("Checking if skill atom exists by skillAtomId: {}", skillAtomId);
         return skillAtomSnapshotRepository.existsBySkillAtomId(skillAtomId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<SkillAtomResponseDto> findAllBasic(Pageable pageable) {
+        log.debug("Finding all skill atoms with basic info, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        Page<SkillAtomSnapshot> pageData = skillAtomSnapshotRepository.findAll(pageable);
+        Page<SkillAtomResponseDto> dtoPage = pageData.map(skillAtomMapper::toResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<SkillAtomResponseDto> searchByNameBasic(String name, Pageable pageable) {
+        log.debug("Searching skill atoms by name: '{}', page: {}, size: {}", name, pageable.getPageNumber(), pageable.getPageSize());
+        Page<SkillAtomSnapshot> pageData = skillAtomSnapshotRepository.findByNameContainingIgnoreCase(name, pageable);
+        Page<SkillAtomResponseDto> dtoPage = pageData.map(skillAtomMapper::toResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<SkillAtomResponseDto> findBySkillAtomIdBasic(UUID skillAtomId) {
+        log.debug("Finding skill atom by ID with basic info: {}", skillAtomId);
+        return skillAtomSnapshotRepository.findBySkillAtomId(skillAtomId)
+                .map(skillAtomMapper::toResponseDto);
     }
 }

--- a/src/main/java/com/capstone/service/impl/SkillCapsuleSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/SkillCapsuleSnapshotServiceImpl.java
@@ -1,17 +1,23 @@
 package com.capstone.service.impl;
 
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.SkillCapsuleResponseDto;
 import com.capstone.exception.*;
 import com.capstone.mapper.SkillCapsuleEventMapper;
+import com.capstone.mapper.SkillCapsuleMapper;
 import com.capstone.model.CapsuleAtomMapping;
 import com.capstone.model.SkillAtomSnapshot;
 import com.capstone.model.SkillCapsuleSnapshot;
 import com.capstone.repository.SkillCapsuleSnapshotRepository;
 import com.capstone.service.SkillAtomSnapshotService;
 import com.capstone.service.SkillCapsuleSnapshotService;
+import com.capstone.util.PaginationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.common.event.SkillCapsuleEvent;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +32,7 @@ public class SkillCapsuleSnapshotServiceImpl implements SkillCapsuleSnapshotServ
 
     private final SkillCapsuleSnapshotRepository skillCapsuleSnapshotRepository;
     private final SkillCapsuleEventMapper skillCapsuleEventMapper;
+    private final SkillCapsuleMapper skillCapsuleMapper;
     private final SkillAtomSnapshotService skillAtomSnapshotService;
 
     @Override
@@ -238,6 +245,58 @@ public class SkillCapsuleSnapshotServiceImpl implements SkillCapsuleSnapshotServ
     public Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(UUID skillCapsuleId) {
         log.debug("Finding capsule with atom mappings by skillCapsuleId: {}", skillCapsuleId);
         return skillCapsuleSnapshotRepository.findBySkillCapsuleIdWithAtomMappings(skillCapsuleId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<SkillCapsuleResponseDto> findAllBasic(Pageable pageable) {
+        log.debug("Finding all skill capsules with basic info, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        Page<SkillCapsuleSnapshot> pageData = skillCapsuleSnapshotRepository.findAll(pageable);
+        Page<SkillCapsuleResponseDto> dtoPage = pageData.map(skillCapsuleMapper::toBasicResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<SkillCapsuleResponseDto> findAllWithAtomSummaries(Pageable pageable) {
+        log.debug("Finding all skill capsules with atom summaries, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        Page<SkillCapsuleSnapshot> pageData = skillCapsuleSnapshotRepository.findAllWithAtomMappings(pageable);
+        Page<SkillCapsuleResponseDto> dtoPage = pageData.map(skillCapsuleMapper::toResponseDtoWithAtoms);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<SkillCapsuleResponseDto> searchByCapsuleNameBasic(String capsuleName, Pageable pageable) {
+        log.debug("Searching skill capsules by name: '{}', page: {}, size: {}", capsuleName, pageable.getPageNumber(), pageable.getPageSize());
+        Page<SkillCapsuleSnapshot> pageData = skillCapsuleSnapshotRepository.findByCapsuleNameContainingIgnoreCase(capsuleName, pageable);
+        Page<SkillCapsuleResponseDto> dtoPage = pageData.map(skillCapsuleMapper::toBasicResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<SkillCapsuleResponseDto> findByDifficultyLevelBasic(String difficultyLevel, Pageable pageable) {
+        log.debug("Finding skill capsules by difficulty level: '{}', page: {}, size: {}", difficultyLevel, pageable.getPageNumber(), pageable.getPageSize());
+        Page<SkillCapsuleSnapshot> pageData = skillCapsuleSnapshotRepository.findByDifficultyLevel(difficultyLevel, pageable);
+        Page<SkillCapsuleResponseDto> dtoPage = pageData.map(skillCapsuleMapper::toBasicResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<SkillCapsuleResponseDto> findBySkillCapsuleIdBasic(UUID skillCapsuleId) {
+        log.debug("Finding skill capsule by ID with basic info: {}", skillCapsuleId);
+        return skillCapsuleSnapshotRepository.findBySkillCapsuleId(skillCapsuleId)
+                .map(skillCapsuleMapper::toBasicResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<SkillCapsuleResponseDto> findBySkillCapsuleIdWithAtomSummaries(UUID skillCapsuleId) {
+        log.debug("Finding skill capsule by ID with atom summaries: {}", skillCapsuleId);
+        return skillCapsuleSnapshotRepository.findBySkillCapsuleIdWithAtomMappings(skillCapsuleId)
+                .map(skillCapsuleMapper::toResponseDtoWithAtoms);
     }
 
     // Helper classes

--- a/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
@@ -1,17 +1,23 @@
 package com.capstone.service.impl;
 
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.dto.response.TalentRouteResponseDto;
 import com.capstone.exception.*;
 import com.capstone.mapper.TalentRouteEventMapper;
+import com.capstone.mapper.TalentRouteMapper;
 import com.capstone.model.GrowthTrackSnapshot;
 import com.capstone.model.RouteTrackMapping;
 import com.capstone.model.TalentRouteSnapshot;
 import com.capstone.repository.TalentRouteSnapshotRepository;
 import com.capstone.service.GrowthTrackSnapshotService;
 import com.capstone.service.TalentRouteSnapshotService;
+import com.capstone.util.PaginationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.common.event.TalentRouteEvent;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +32,7 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
 
     private final TalentRouteSnapshotRepository talentRouteSnapshotRepository;
     private final TalentRouteEventMapper talentRouteEventMapper;
+    private final TalentRouteMapper talentRouteMapper;
     private final GrowthTrackSnapshotService growthTrackSnapshotService;
 
     @Override
@@ -229,6 +236,90 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
     public Optional<TalentRouteSnapshot> findByTalentRouteIdWithTrackMappings(UUID talentRouteId) {
         log.debug("Finding route with track mappings by talentRouteId: {}", talentRouteId);
         return talentRouteSnapshotRepository.findByTalentRouteIdWithTrackMappings(talentRouteId);
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<TalentRouteSnapshot> findAll(Pageable pageable) {
+        log.debug("Finding all talent routes with pagination: page={}, size={}",
+            pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findAll(pageable);
+        return PaginationUtil.toPaginatedResponse(pageData);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<TalentRouteSnapshot> findAllWithTrackMappings(Pageable pageable) {
+        log.debug("Finding all talent routes with track mappings: page={}, size={}",
+            pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findAllWithTrackMappings(pageable);
+        return PaginationUtil.toPaginatedResponse(pageData);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<TalentRouteSnapshot> searchByRouteName(String routeName, Pageable pageable) {
+        log.debug("Searching talent routes by name '{}': page={}, size={}",
+            routeName, pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findByRouteNameContainingIgnoreCase(routeName, pageable);
+        return PaginationUtil.toPaginatedResponse(pageData);
+    }
+
+    // ===== NEW CLEAN DTO-BASED METHODS =====
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<TalentRouteResponseDto> findAllBasic(Pageable pageable) {
+        log.debug("Finding all talent routes (basic) with pagination: page={}, size={}",
+            pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findAll(pageable);
+        Page<TalentRouteResponseDto> dtoPage = pageData.map(talentRouteMapper::toBasicResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<TalentRouteResponseDto> findAllWithTrackSummaries(Pageable pageable) {
+        log.debug("Finding all talent routes with track summaries: page={}, size={}",
+            pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findAllWithTrackMappings(pageable);
+        Page<TalentRouteResponseDto> dtoPage = pageData.map(talentRouteMapper::toResponseDtoWithTracks);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDto<TalentRouteResponseDto> searchByRouteNameBasic(String routeName, Pageable pageable) {
+        log.debug("Searching talent routes (basic) by name '{}': page={}, size={}",
+            routeName, pageable.getPageNumber(), pageable.getPageSize());
+
+        Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findByRouteNameContainingIgnoreCase(routeName, pageable);
+        Page<TalentRouteResponseDto> dtoPage = pageData.map(talentRouteMapper::toBasicResponseDto);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<TalentRouteResponseDto> findByTalentRouteIdBasic(UUID talentRouteId) {
+        log.debug("Finding talent route (basic) by talentRouteId: {}", talentRouteId);
+
+        return talentRouteSnapshotRepository.findByTalentRouteId(talentRouteId)
+                .map(talentRouteMapper::toBasicResponseDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<TalentRouteResponseDto> findByTalentRouteIdWithTrackSummaries(UUID talentRouteId) {
+        log.debug("Finding talent route with track summaries by talentRouteId: {}", talentRouteId);
+
+        return talentRouteSnapshotRepository.findByTalentRouteIdWithTrackMappings(talentRouteId)
+                .map(talentRouteMapper::toResponseDtoWithTracks);
     }
 
     // Helper classes

--- a/src/main/java/com/capstone/util/PaginationUtil.java
+++ b/src/main/java/com/capstone/util/PaginationUtil.java
@@ -1,0 +1,22 @@
+package com.capstone.util;
+
+import com.capstone.dto.response.PaginatedResponseDto;
+import com.capstone.model.PaginationMetadata;
+import org.springframework.data.domain.Page;
+
+public class PaginationUtil {
+
+    public static <T> PaginatedResponseDto<T> toPaginatedResponse(Page<T> pageData) {
+        return PaginatedResponseDto.<T>builder()
+                .items(pageData.getContent())
+                .pagination(PaginationMetadata.builder()
+                        .page(pageData.getNumber())
+                        .size(pageData.getSize())
+                        .totalElements(pageData.getTotalElements())
+                        .totalPages(pageData.getTotalPages())
+                        .hasNext(pageData.hasNext())
+                        .hasPrevious(pageData.hasPrevious())
+                        .build())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
   config:
     import: optional:configserver:${CONFIG_SERVER_URL}
 
+  jackson:
+    serialization:
+      fail-on-empty-beans: false
+
   kafka:
     bootstrap-servers: ${BOOTSTRAP_SERVER}
     properties:


### PR DESCRIPTION
# 🚀   Pull Request: Roadmap API Implementation
### 🎫   Jira Ticket
[:link:  SPRINT-2/VER-20: API to fetch skill roadmap with grouped tags and dependencies](https://amali-tech.atlassian.net/browse/VER-117)
---
## :white_check_mark:  Summary
This PR provides API for retrieving `roadmap` per `talent-route` with all it's associated `growth-track`, `skill-capsule` and `skill-atom`.
---
## :pushpin:  Features  Added
- [x] Created Roadmap Controllers
- [x] Implemented Service Logic to retrieve talent-routes with all their associated mappings 
- [x] Proper mapping using `mapstruct` for performance optimization 
---
## 🚧  Next Task
- Implementing Redis Integratrion for performance optimization