### PR TITLE
Get the learner started on their learning path

### DIFF
--- a/src/main/java/com/capstone/controller/RoadmapController.java
+++ b/src/main/java/com/capstone/controller/RoadmapController.java
@@ -1,6 +1,6 @@
 package com.capstone.controller;
 
-import com.capstone.dto.route.RoadmapRequestDto;
+import com.capstone.dto.roadmap.RoadmapRequestDto;
 import com.capstone.service.LearnerRoadmapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/capstone/controller/RoadmapController.java
+++ b/src/main/java/com/capstone/controller/RoadmapController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("roadmap")
+@RequestMapping("/api/v1/roadmap/")
 @Tag(name = "Roadmap Controller", description = "Manage all roadmap's api")
 public class RoadmapController {
     private final LearnerRoadmapService learnerRoadmapService;

--- a/src/main/java/com/capstone/controller/RoadmapController.java
+++ b/src/main/java/com/capstone/controller/RoadmapController.java
@@ -1,6 +1,8 @@
 package com.capstone.controller;
 
 import com.capstone.dto.roadmap.RoadmapRequestDto;
+import com.capstone.dto.roadmap.StartAtomProgressRequestDto;
+import com.capstone.service.LearnerProgressService;
 import com.capstone.service.LearnerRoadmapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,10 +17,18 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Roadmap Controller", description = "Manage all roadmap's api")
 public class RoadmapController {
     private final LearnerRoadmapService learnerRoadmapService;
+    private final LearnerProgressService learnerProgressService;
     @PostMapping()
     @Operation(summary = "Assign track", description = "This end point allows a learner to select talent route")
     public ResponseEntity<String> assignRouteToLearner(@RequestBody RoadmapRequestDto roadmapRequestDto) {
         learnerRoadmapService.assignLearnerToTalentRoute(roadmapRequestDto);
+        return ResponseEntity.status(HttpStatus.OK).body("response");
+    }
+
+    @PostMapping("/start-progress")
+    @Operation(summary = "Start progress", description = "This end point gets a learner to start tracking progress")
+    public ResponseEntity<String> startTrackingProgress(@RequestBody StartAtomProgressRequestDto dto) {
+        learnerProgressService.startAtomProgress(dto);
         return ResponseEntity.status(HttpStatus.OK).body("response");
     }
 

--- a/src/main/java/com/capstone/dto/roadmap/RoadmapRequestDto.java
+++ b/src/main/java/com/capstone/dto/roadmap/RoadmapRequestDto.java
@@ -1,4 +1,4 @@
-package com.capstone.dto.route;
+package com.capstone.dto.roadmap;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/capstone/dto/roadmap/StartAtomProgressRequestDto.java
+++ b/src/main/java/com/capstone/dto/roadmap/StartAtomProgressRequestDto.java
@@ -1,0 +1,17 @@
+package com.capstone.dto.roadmap;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StartAtomProgressRequestDto {
+    UUID learnerId;
+    UUID atomId;
+}

--- a/src/main/java/com/capstone/dto/roadmap/StartAtomProgressRequestDto.java
+++ b/src/main/java/com/capstone/dto/roadmap/StartAtomProgressRequestDto.java
@@ -14,4 +14,5 @@ import java.util.UUID;
 public class StartAtomProgressRequestDto {
     UUID learnerId;
     UUID atomId;
+    UUID trackId;
 }

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -202,4 +202,18 @@ public class GlobalExceptionHandler {
                 .body(ApiResponseDto.error(ex.getMessage(), "Route-track mapping failed"));
     }
 
+    @ExceptionHandler(RoadmapNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleRoadmapNotFoundException(RoadmapNotFoundException ex) {
+        log.error("Roadmap not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseDto.error(ex.getMessage(), "Roadmap not found"));
+    }
+
+    @ExceptionHandler(RoadmapExistException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleRoadmapExistException(RoadmapExistException ex) {
+        log.error("Roadmap exists: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(ex.getMessage(), "Roadmap exists"));
+    }
+
 }

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -223,4 +223,11 @@ public class GlobalExceptionHandler {
                 .body(ApiResponseDto.error(ex.getMessage(), "Progress not found"));
     }
 
+    @ExceptionHandler(ProgressExistException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleProgressExistException(ProgressExistException ex) {
+        log.error("Progress exist: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponseDto.error(ex.getMessage(), "Progress exist"));
+    }
+
 }

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -216,4 +216,11 @@ public class GlobalExceptionHandler {
                 .body(ApiResponseDto.error(ex.getMessage(), "Roadmap exists"));
     }
 
+    @ExceptionHandler(ProgressNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleProgressNotFoundException(ProgressNotFoundException ex) {
+        log.error("Progress not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseDto.error(ex.getMessage(), "Progress not found"));
+    }
+
 }

--- a/src/main/java/com/capstone/exception/ProgressExistException.java
+++ b/src/main/java/com/capstone/exception/ProgressExistException.java
@@ -1,0 +1,7 @@
+package com.capstone.exception;
+
+public class ProgressExistException extends RuntimeException {
+    public ProgressExistException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/exception/ProgressNotFoundException.java
+++ b/src/main/java/com/capstone/exception/ProgressNotFoundException.java
@@ -1,0 +1,7 @@
+package com.capstone.exception;
+
+public class ProgressNotFoundException extends RuntimeException {
+    public ProgressNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/exception/RoadmapExistException.java
+++ b/src/main/java/com/capstone/exception/RoadmapExistException.java
@@ -1,0 +1,7 @@
+package com.capstone.exception;
+
+public class RoadmapExistException extends RuntimeException {
+    public RoadmapExistException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/exception/RoadmapNotFoundException.java
+++ b/src/main/java/com/capstone/exception/RoadmapNotFoundException.java
@@ -1,0 +1,7 @@
+package com.capstone.exception;
+
+public class RoadmapNotFoundException extends RuntimeException {
+    public RoadmapNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/capstone/repository/LearnerAtomProgressRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerAtomProgressRepository.java
@@ -2,10 +2,26 @@ package com.capstone.repository;
 
 import com.capstone.model.LearnerAtomProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface LearnerAtomProgressRepository extends JpaRepository<LearnerAtomProgress, UUID> {
+
+    @Query("""
+        SELECT lap
+        FROM LearnerAtomProgress lap
+        JOIN lap.learnerCapsuleProgress lcp
+        JOIN lcp.learnerTrackProgress ltp
+        JOIN ltp.learnerRoadmap lr
+        WHERE lr.userId = :learnerId
+          AND lap.skillAtom.skillAtomId = :atomId
+    """)
+    Optional<LearnerAtomProgress> findByLearnerIdAndAtomId(@Param("learnerId") UUID learnerId,
+                                                           @Param("atomId") UUID atomId);
+
 }

--- a/src/main/java/com/capstone/repository/LearnerAtomProgressRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerAtomProgressRepository.java
@@ -19,9 +19,11 @@ public interface LearnerAtomProgressRepository extends JpaRepository<LearnerAtom
         JOIN lcp.learnerTrackProgress ltp
         JOIN ltp.learnerRoadmap lr
         WHERE lr.userId = :learnerId
+          AND ltp.growthTrack.growthTrackId = :trackId
           AND lap.skillAtom.skillAtomId = :atomId
     """)
     Optional<LearnerAtomProgress> findByLearnerIdAndAtomId(@Param("learnerId") UUID learnerId,
-                                                           @Param("atomId") UUID atomId);
+                                                           @Param("atomId") UUID atomId,
+                                                           @Param("trackId") UUID trackId);
 
 }

--- a/src/main/java/com/capstone/repository/LearnerRoadmapRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerRoadmapRepository.java
@@ -2,10 +2,22 @@ package com.capstone.repository;
 
 import com.capstone.model.LearnerRoadmap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface LearnerRoadmapRepository extends JpaRepository<LearnerRoadmap, UUID> {
+
+    @Query("""
+        SELECT rm FROM LearnerRoadmap rm
+        WHERE rm.userId = :userId
+        AND rm.talentRoute.talentRouteId = :talentRouteId
+    """)
+    Optional<LearnerRoadmap> findByUserIdAndTalentRouteId(@Param("userId") UUID userId,
+                                                          @Param("talentRouteId") UUID talentRouteId);
+
 }

--- a/src/main/java/com/capstone/service/LearnerProgressService.java
+++ b/src/main/java/com/capstone/service/LearnerProgressService.java
@@ -1,0 +1,7 @@
+package com.capstone.service;
+
+import com.capstone.dto.roadmap.StartAtomProgressRequestDto;
+
+public interface LearnerProgressService {
+    String startAtomProgress(StartAtomProgressRequestDto startAtomProgressRequestDto);
+}

--- a/src/main/java/com/capstone/service/LearnerRoadmapService.java
+++ b/src/main/java/com/capstone/service/LearnerRoadmapService.java
@@ -1,6 +1,6 @@
 package com.capstone.service;
 
-import com.capstone.dto.route.RoadmapRequestDto;
+import com.capstone.dto.roadmap.RoadmapRequestDto;
 
 public interface LearnerRoadmapService {
     String assignLearnerToTalentRoute(RoadmapRequestDto roadmapRequestDto);

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -19,7 +19,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
     @Override
     public String startAtomProgress(StartAtomProgressRequestDto startAtomProgressRequestDto) {
         LearnerAtomProgress atomProgress = learnerAtomProgressRepository.findByLearnerIdAndAtomId(startAtomProgressRequestDto.getLearnerId(),
-                startAtomProgressRequestDto.getAtomId())
+                startAtomProgressRequestDto.getAtomId(), startAtomProgressRequestDto.getTrackId())
                 .orElseThrow(() -> new ProgressNotFoundException("Atom progress not found for this learner"));
 
         if(atomProgress.getStatus().equals(ProgressStatus.NOT_STARTED)){
@@ -28,6 +28,8 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
             atomProgress.setStatus(ProgressStatus.IN_PROGRESS);
         }
 
-        return null;
+        learnerAtomProgressRepository.save(atomProgress);
+
+        return "Learner has started";
     }
 }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -3,12 +3,12 @@ package com.capstone.service.impl;
 import com.capstone.dto.roadmap.StartAtomProgressRequestDto;
 import com.capstone.exception.ProgressExistException;
 import com.capstone.exception.ProgressNotFoundException;
-import com.capstone.model.LearnerAtomProgress;
-import com.capstone.model.ProgressStatus;
+import com.capstone.model.*;
 import com.capstone.repository.LearnerAtomProgressRepository;
 import com.capstone.service.LearnerProgressService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -17,12 +17,23 @@ import java.time.LocalDateTime;
 public class LearnerProgressServiceImpl implements LearnerProgressService {
     private final LearnerAtomProgressRepository learnerAtomProgressRepository;
 
+    @Transactional
     @Override
     public String startAtomProgress(StartAtomProgressRequestDto startAtomProgressRequestDto) {
         LearnerAtomProgress atomProgress = learnerAtomProgressRepository.findByLearnerIdAndAtomId(startAtomProgressRequestDto.getLearnerId(),
                 startAtomProgressRequestDto.getAtomId(), startAtomProgressRequestDto.getTrackId())
                 .orElseThrow(() -> new ProgressNotFoundException("Atom progress not found for this learner"));
 
+        startAtomProgress(atomProgress); // start atom progress
+        LearnerCapsuleProgress capsuleProgress = getCapsuleProgress(atomProgress); // start capsule progress
+        startTrackProgress(capsuleProgress); // start growth track progress
+
+        learnerAtomProgressRepository.save(atomProgress);
+
+        return "Learner has started";
+    }
+
+    private void startAtomProgress(LearnerAtomProgress atomProgress){
         if(atomProgress.getStatus().equals(ProgressStatus.NOT_STARTED)){
             atomProgress.setStartedAt(LocalDateTime.now());
             atomProgress.setUpdatedAt(LocalDateTime.now());
@@ -30,9 +41,24 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         }else{
             throw new ProgressExistException("You have already started your roadmap");
         }
+    }
 
-        learnerAtomProgressRepository.save(atomProgress);
+    private LearnerCapsuleProgress getCapsuleProgress(LearnerAtomProgress atomProgress){
+        LearnerCapsuleProgress capsuleProgress = atomProgress.getLearnerCapsuleProgress();
+        if(capsuleProgress.getStatus().equals(ProgressStatus.NOT_STARTED)){
+            capsuleProgress.setStartedAt(LocalDateTime.now());
+            capsuleProgress.setUpdatedAt(LocalDateTime.now());
+            capsuleProgress.setStatus(ProgressStatus.IN_PROGRESS);
+        }
+        return capsuleProgress;
+    }
 
-        return "Learner has started";
+    private void startTrackProgress(LearnerCapsuleProgress capsuleProgress){
+        LearnerTrackProgress trackProgress = capsuleProgress.getLearnerTrackProgress();
+        if(trackProgress.getStatus().equals(ProgressStatus.NOT_STARTED)){
+            trackProgress.setStartedAt(LocalDateTime.now());
+            trackProgress.setStartedAt(LocalDateTime.now());
+            trackProgress.setStatus(ProgressStatus.IN_PROGRESS);
+        }
     }
 }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -1,6 +1,7 @@
 package com.capstone.service.impl;
 
 import com.capstone.dto.roadmap.StartAtomProgressRequestDto;
+import com.capstone.exception.ProgressExistException;
 import com.capstone.exception.ProgressNotFoundException;
 import com.capstone.model.LearnerAtomProgress;
 import com.capstone.model.ProgressStatus;
@@ -26,6 +27,8 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
             atomProgress.setStartedAt(LocalDateTime.now());
             atomProgress.setUpdatedAt(LocalDateTime.now());
             atomProgress.setStatus(ProgressStatus.IN_PROGRESS);
+        }else{
+            throw new ProgressExistException("You have already started your roadmap");
         }
 
         learnerAtomProgressRepository.save(atomProgress);

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -1,0 +1,33 @@
+package com.capstone.service.impl;
+
+import com.capstone.dto.roadmap.StartAtomProgressRequestDto;
+import com.capstone.exception.ProgressNotFoundException;
+import com.capstone.model.LearnerAtomProgress;
+import com.capstone.model.ProgressStatus;
+import com.capstone.repository.LearnerAtomProgressRepository;
+import com.capstone.service.LearnerProgressService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LearnerProgressServiceImpl implements LearnerProgressService {
+    private final LearnerAtomProgressRepository learnerAtomProgressRepository;
+
+    @Override
+    public String startAtomProgress(StartAtomProgressRequestDto startAtomProgressRequestDto) {
+        LearnerAtomProgress atomProgress = learnerAtomProgressRepository.findByLearnerIdAndAtomId(startAtomProgressRequestDto.getLearnerId(),
+                startAtomProgressRequestDto.getAtomId())
+                .orElseThrow(() -> new ProgressNotFoundException("Atom progress not found for this learner"));
+
+        if(atomProgress.getStatus().equals(ProgressStatus.NOT_STARTED)){
+            atomProgress.setStartedAt(LocalDateTime.now());
+            atomProgress.setUpdatedAt(LocalDateTime.now());
+            atomProgress.setStatus(ProgressStatus.IN_PROGRESS);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
@@ -9,6 +9,7 @@ import com.capstone.repository.*;
 import com.capstone.service.LearnerRoadmapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -22,6 +23,8 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
     private final RouteTrackMappingRepository routeTrackMappingRepository;
     private final GrowthTrackCapsuleMappingRepository growthTrackCapsuleMappingRepository;
     private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
+
+    @Transactional
     @Override
     public String assignLearnerToTalentRoute(RoadmapRequestDto roadmapRequestDto) {
 

--- a/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
@@ -1,6 +1,7 @@
 package com.capstone.service.impl;
 
 import com.capstone.dto.route.RoadmapRequestDto;
+import com.capstone.exception.RoadmapExistException;
 import com.capstone.exception.TalentRouteNotFoundException;
 import com.capstone.exception.UserNotFoundException;
 import com.capstone.model.*;
@@ -46,6 +47,10 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
 
         if(userSnapshotRepository.findByUserId(learnerId).isEmpty()){
             throw new UserNotFoundException("A learner provided doesn't exist");
+        }
+
+        if(learnerRoadmapRepository.findByUserIdAndTalentRouteId(learnerId, talentRouteId).isPresent()){
+            throw new RoadmapExistException("You are already enrolled in this roadmap");
         }
 
         return LearnerRoadmap.builder()

--- a/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
@@ -1,6 +1,6 @@
 package com.capstone.service.impl;
 
-import com.capstone.dto.route.RoadmapRequestDto;
+import com.capstone.dto.roadmap.RoadmapRequestDto;
 import com.capstone.exception.RoadmapExistException;
 import com.capstone.exception.TalentRouteNotFoundException;
 import com.capstone.exception.UserNotFoundException;


### PR DESCRIPTION
# 🚀 Pull Request: Get the learner started on their learning path

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-20: Implement Learner Progress Tracking from Skill Atom to Talent route.](https://amali-tech.atlassian.net/browse/VER-118)

---

## ✅ Summary

These changes introduce the starting point of a learner's progress. When a learner decides to start taking a course, the system automatically updates the progress from 'NOT_STARTED' to 'IN_PROGRESS' at both the atom level and the growth track level.

---

## 📌 Feature

- [x] Update learner's atom progress to IN_PROGRESS
- [x] Update learner's capsule progress to IN_PROGRESS
- [x] Update learner's growth track progress to IN_PROGRESS.

---

## 🚧 Next Task

- Calculate the learner's progress from the atom level to the roadmap level.