### PR TITLE
Recalculate learner progress for consistency

### DIFF
--- a/src/main/java/com/capstone/controller/RoadmapController.java
+++ b/src/main/java/com/capstone/controller/RoadmapController.java
@@ -1,5 +1,6 @@
 package com.capstone.controller;
 
+import com.capstone.dto.roadmap.RecalculateProgressRequestDto;
 import com.capstone.dto.roadmap.RoadmapRequestDto;
 import com.capstone.dto.roadmap.AtomProgressRequestDto;
 import com.capstone.service.LearnerProgressService;
@@ -36,6 +37,13 @@ public class RoadmapController {
     @Operation(summary = "Update progress", description = "This end point calculates learner's progress")
     public ResponseEntity<String> updateLearnerProgress(@RequestBody AtomProgressRequestDto dto) {
         learnerProgressService.completeAtomProgress(dto);
+        return ResponseEntity.status(HttpStatus.OK).body("response");
+    }
+
+    @PostMapping("/recalculate-progress")
+    @Operation(summary = "Recalculate", description = "This end point recalculates learner's progress for consistency")
+    public ResponseEntity<String> recalculateLearnerProgress(@RequestBody RecalculateProgressRequestDto dto) {
+        learnerProgressService.recalculateAndUpdateLearnerRoadmap(dto);
         return ResponseEntity.status(HttpStatus.OK).body("response");
     }
 

--- a/src/main/java/com/capstone/dto/roadmap/RecalculateProgressRequestDto.java
+++ b/src/main/java/com/capstone/dto/roadmap/RecalculateProgressRequestDto.java
@@ -1,0 +1,17 @@
+package com.capstone.dto.roadmap;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecalculateProgressRequestDto {
+    UUID learnerId;
+    UUID talentRouteId;
+}

--- a/src/main/java/com/capstone/service/LearnerProgressService.java
+++ b/src/main/java/com/capstone/service/LearnerProgressService.java
@@ -1,8 +1,12 @@
 package com.capstone.service;
 
 import com.capstone.dto.roadmap.AtomProgressRequestDto;
+import com.capstone.dto.roadmap.RecalculateProgressRequestDto;
+
+import java.util.UUID;
 
 public interface LearnerProgressService {
     String startAtomProgress(AtomProgressRequestDto atomProgressRequestDto);
     String completeAtomProgress(AtomProgressRequestDto atomProgressRequestDto);
+    String recalculateAndUpdateLearnerRoadmap(RecalculateProgressRequestDto dto);
 }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -6,10 +6,7 @@ import com.capstone.exception.ProgressExistException;
 import com.capstone.exception.ProgressNotFoundException;
 import com.capstone.exception.TalentRouteNotFoundException;
 import com.capstone.model.*;
-import com.capstone.repository.GrowthTrackCapsuleMappingRepository;
-import com.capstone.repository.LearnerAtomProgressRepository;
-import com.capstone.repository.LearnerRoadmapRepository;
-import com.capstone.repository.RouteTrackMappingRepository;
+import com.capstone.repository.*;
 import com.capstone.service.LearnerProgressService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,6 +26,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
     private final LearnerRoadmapRepository learnerRoadmapRepository;
     private final RouteTrackMappingRepository routeTrackMappingRepository;
     private final GrowthTrackCapsuleMappingRepository growthTrackCapsuleMappingRepository;
+    private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
 
     @Transactional
     @Override
@@ -157,7 +155,8 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                 .orElseThrow(() -> new TalentRouteNotFoundException("The learner isn't enrolled in this roadmap"));
 
         updateLearnerRoadmap(talentRoute); // first update learner roadmap
-        return null;
+
+        return "Learner progress recalculated";
     }
 
     private void updateLearnerRoadmap(LearnerRoadmap talentRoute){
@@ -216,6 +215,39 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                 learnerGrowthTrackProgress.getLearnerCapsuleProgresses().add(learnerCapsuleProgress);
 
                 existingCapsules.put(capsuleId, learnerCapsuleProgress); // update learnerCapsule progress
+            }
+
+            // add non-existing atom to capsule progress
+            addNewAtomsToCapsuleProgress(learnerCapsuleProgress, capsuleId);
+
+        }
+    }
+
+    private void addNewAtomsToCapsuleProgress(LearnerCapsuleProgress learnerCapsuleProgress, UUID capsuleId){
+        //find all the atoms in the capsule(new one + existing in the capsule progress)
+        List<SkillAtomSnapshot> allAtoms =
+                capsuleAtomMappingRepository.findAtomsByCapsuleId(capsuleId);
+
+        // find the existing atoms in the capsule progress
+        Map<UUID, LearnerAtomProgress> existingAtoms = learnerCapsuleProgress.getLearnerAtomProgresses().stream()
+                .collect(Collectors.toMap(cp->cp.getSkillAtom().getSkillAtomId(), cp->cp));
+
+        for(SkillAtomSnapshot atom: allAtoms){
+            UUID atomId = atom.getSkillAtomId();
+            LearnerAtomProgress learnerAtomProgress = existingAtoms.get(atomId);
+
+            if(learnerAtomProgress == null){ // add only new the ones aren't in the capsule progress
+                learnerAtomProgress = LearnerAtomProgress.builder()
+                        .learnerCapsuleProgress(learnerCapsuleProgress)
+                        .skillAtom(atom)
+                        .status(ProgressStatus.NOT_STARTED)
+                        .isCompleted(false)
+                        .build();
+
+                // attach the learner atom progress to capsule progress
+                learnerCapsuleProgress.getLearnerAtomProgresses().add(learnerAtomProgress);
+
+                existingAtoms.put(atomId, learnerAtomProgress); // update learnerAtom progress
             }
 
         }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -1,24 +1,34 @@
 package com.capstone.service.impl;
 
 import com.capstone.dto.roadmap.AtomProgressRequestDto;
+import com.capstone.dto.roadmap.RecalculateProgressRequestDto;
 import com.capstone.exception.ProgressExistException;
 import com.capstone.exception.ProgressNotFoundException;
+import com.capstone.exception.TalentRouteNotFoundException;
 import com.capstone.model.*;
+import com.capstone.repository.GrowthTrackCapsuleMappingRepository;
 import com.capstone.repository.LearnerAtomProgressRepository;
 import com.capstone.repository.LearnerRoadmapRepository;
+import com.capstone.repository.RouteTrackMappingRepository;
 import com.capstone.service.LearnerProgressService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class LearnerProgressServiceImpl implements LearnerProgressService {
     private final LearnerAtomProgressRepository learnerAtomProgressRepository;
     private final LearnerRoadmapRepository learnerRoadmapRepository;
+    private final RouteTrackMappingRepository routeTrackMappingRepository;
+    private final GrowthTrackCapsuleMappingRepository growthTrackCapsuleMappingRepository;
 
     @Transactional
     @Override
@@ -139,4 +149,43 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         return learnerRoadmap;
     }
 
+    @Transactional
+    @Override
+    public String recalculateAndUpdateLearnerRoadmap(RecalculateProgressRequestDto dto) {
+        LearnerRoadmap talentRoute = learnerRoadmapRepository
+                .findByUserIdAndTalentRouteId(dto.getLearnerId(), dto.getTalentRouteId())
+                .orElseThrow(() -> new TalentRouteNotFoundException("The learner isn't enrolled in this roadmap"));
+
+        updateLearnerRoadmap(talentRoute); // first update learner roadmap
+        return null;
+    }
+
+    private void updateLearnerRoadmap(LearnerRoadmap talentRoute){
+        // find all growth tracks that belong to talent route (new ones + existing in the roadmap)
+        List<GrowthTrackSnapshot> allGrowthTracks = routeTrackMappingRepository
+                .findGrowthTracksByTalentRouteId(talentRoute.getTalentRoute().getTalentRouteId());
+
+        // find the existing growth tracks in the roadmap
+        Map<UUID, LearnerTrackProgress> existingTracks = talentRoute.getLearnerTrackProgresses().stream()
+                .collect(Collectors.toMap(tp -> tp.getGrowthTrack().getGrowthTrackId(), tp -> tp));
+
+        for(GrowthTrackSnapshot growthTrack: allGrowthTracks){
+            UUID growthTrackId = growthTrack.getGrowthTrackId();
+            LearnerTrackProgress learnerGrowthTrackProgress = existingTracks.get(growthTrackId);
+            if (learnerGrowthTrackProgress == null) { // add only the ones that aren't in the roadmap
+                // add new growth tracks to this learner roadmap
+                learnerGrowthTrackProgress = LearnerTrackProgress.builder()
+                        .learnerRoadmap(talentRoute)
+                        .growthTrack(growthTrack)
+                        .status(ProgressStatus.NOT_STARTED)
+                        .progressPercentage(0)
+                        .build();
+
+                talentRoute.getLearnerTrackProgresses().add(learnerGrowthTrackProgress); // add growth track to roadmap
+
+                existingTracks.put(growthTrackId, learnerGrowthTrackProgress); // update learnerTrackProgress
+            }
+
+        }
+    }
 }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -185,6 +185,38 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
 
                 existingTracks.put(growthTrackId, learnerGrowthTrackProgress); // update learnerTrackProgress
             }
+            // add non-existing capsules to the growth track progress
+            addNewCapsulesToGrowthTrackProgress(learnerGrowthTrackProgress, growthTrackId);
+
+        }
+    }
+
+    private void addNewCapsulesToGrowthTrackProgress(LearnerTrackProgress learnerGrowthTrackProgress, UUID growthTrackId){
+        //find all the capsule in the growth track(new one + existing in the growth track progress)
+        List<SkillCapsuleSnapshot> allCapsules =
+                growthTrackCapsuleMappingRepository.findCapsulesByGrowthTrackId(growthTrackId);
+
+        // find the existing capsules in the growth track progress
+        Map<UUID, LearnerCapsuleProgress> existingCapsules = learnerGrowthTrackProgress.getLearnerCapsuleProgresses().stream()
+                .collect(Collectors.toMap(cp->cp.getSkillCapsule().getSkillCapsuleId(), cp->cp));
+
+        for(SkillCapsuleSnapshot capsule: allCapsules){
+            UUID capsuleId = capsule.getSkillCapsuleId();
+            LearnerCapsuleProgress learnerCapsuleProgress = existingCapsules.get(capsuleId);
+
+            if(learnerCapsuleProgress == null){ // add only new the ones aren't in the growth track progress
+                learnerCapsuleProgress = LearnerCapsuleProgress.builder()
+                        .learnerTrackProgress(learnerGrowthTrackProgress)
+                        .skillCapsule(capsule)
+                        .status(ProgressStatus.NOT_STARTED)
+                        .progressPercentage(0)
+                        .build();
+
+                // attach the learner capsule progress to growth track progress
+                learnerGrowthTrackProgress.getLearnerCapsuleProgresses().add(learnerCapsuleProgress);
+
+                existingCapsules.put(capsuleId, learnerCapsuleProgress); // update learnerCapsule progress
+            }
 
         }
     }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -155,6 +155,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                 .orElseThrow(() -> new TalentRouteNotFoundException("The learner isn't enrolled in this roadmap"));
 
         updateLearnerRoadmap(talentRoute); // first update learner roadmap
+        recalculateProgress(talentRoute); // recalculate learner progress
 
         return "Learner progress recalculated";
     }
@@ -251,5 +252,87 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
             }
 
         }
+    }
+
+    public void recalculateProgress(LearnerRoadmap talentRoute) {
+        // Recalculate all growth tracks progresses
+        List<LearnerTrackProgress> growthTracks = talentRoute.getLearnerTrackProgresses();
+        int totalGrowthTrackPercentage = getTotalGrowthTrackPercentageInTalentRoute(growthTracks);
+
+        // Recalculate talentRoute percentage
+        recalculateTalentRoutePercentage(talentRoute, growthTracks, totalGrowthTrackPercentage);
+
+    }
+
+    private void recalculateTalentRoutePercentage(LearnerRoadmap talentRoute,
+                                                  List<LearnerTrackProgress> growthTracks,
+                                                  int totalGrowthTrackPercentage ){
+        int talentRoutePercentage = growthTracks.isEmpty() ? 0 : totalGrowthTrackPercentage / growthTracks.size();
+        talentRoute.setOverallProgressPercentage(talentRoutePercentage);
+
+        if (talentRoutePercentage == 0) {
+            talentRoute.setEnrollmentStatus(EnrollmentStatus.ACTIVE); // still enrolled, not started
+        } else if (talentRoutePercentage == 100) {
+            talentRoute.setEnrollmentStatus(EnrollmentStatus.COMPLETED);
+        }
+
+        learnerRoadmapRepository.save(talentRoute); // store roadmap updated progress in the Database
+    }
+
+    private int getTotalGrowthTrackPercentageInTalentRoute(List<LearnerTrackProgress> growthTracks){
+        int totalTrackPercentage = 0; // this is required to update roadmap overall percentage
+
+        // loop throw each growth track progress to recalculate percentage and the get the new percentage
+        for (LearnerTrackProgress growthTrackProgress : growthTracks) {
+            // first get the total percentage of capsule to calculate the growth track percentage
+            List<LearnerCapsuleProgress> capsules = growthTrackProgress.getLearnerCapsuleProgresses();
+            int totalCapsulePercentage = getTotalCapsulePercentageInGrowthTrack(capsules);
+
+            // update current growth track progress information
+            int currentGrowthTrackPercentage = capsules.isEmpty() ? 0 : totalCapsulePercentage / capsules.size();
+            growthTrackProgress.setProgressPercentage(currentGrowthTrackPercentage);
+
+            // set growth track status
+            switch (currentGrowthTrackPercentage) {
+                case 0 -> growthTrackProgress.setStatus(ProgressStatus.NOT_STARTED);
+                case 100 -> growthTrackProgress.setStatus(ProgressStatus.COMPLETED);
+                default -> growthTrackProgress.setStatus(ProgressStatus.IN_PROGRESS);
+            }
+
+            totalTrackPercentage += currentGrowthTrackPercentage;
+        }
+        return totalTrackPercentage;
+    }
+
+    private int getTotalCapsulePercentageInGrowthTrack(List<LearnerCapsuleProgress> capsules){
+        int totalCapsulePercentage = 0; // this is required to calculate the growth track percentage
+
+        // loop throw each capsule progress to recalculate percentage and the get the new percentage
+        for (LearnerCapsuleProgress capsuleProgress : capsules) {
+            // first calculate the atoms completion
+            List<LearnerAtomProgress> atoms = capsuleProgress.getLearnerAtomProgresses();
+
+            int completedAtoms = (int) atoms.stream()
+                    .filter(LearnerAtomProgress::isCompleted)
+                    .count();
+
+            int currentCapsulePercentage = atoms.isEmpty() ? 0 :
+                    (completedAtoms * 100) / atoms.size();
+
+            capsuleProgress.setProgressPercentage(currentCapsulePercentage);
+
+            // update current capsule progress information
+            switch (currentCapsulePercentage) {
+                case 0 ->
+                        capsuleProgress.setStatus(ProgressStatus.NOT_STARTED);
+                case 100 ->
+                        capsuleProgress.setStatus(ProgressStatus.COMPLETED);
+                default ->
+                        capsuleProgress.setStatus(ProgressStatus.IN_PROGRESS);
+            }
+
+            totalCapsulePercentage += currentCapsulePercentage;
+        }
+        return totalCapsulePercentage;
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request: Recalculate learner progress for consistency

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-20: Implement Learner Progress Tracking from Skill Atom to Talent route.](https://amali-tech.atlassian.net/browse/VER-118)

---

## ✅ Summary

These changes recalculate the learner's progress in case there are some new additional atoms, capsules, and growth tracks assigned to a learner's roadmap. This PR first updates the new additional track to the learning path, then recalculates the learner's progress for each level.

---

## 📌 Feature

- [x] Update learner progress track for new atoms, capsules, and growth track
- [x] Recalculate percentage for each level to make growth track consistent

---

## 🚧 Next Task

- Display or fetch roadmap data based on the client request.