### PR TITLE
Feat: Learner Roadmap Progress Endpoints 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,12 +132,6 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-<!--        swagger ui-->
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.5.0</version>
-        </dependency>
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka-test</artifactId>

--- a/src/main/java/com/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.capstone.security.UserContextFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -48,10 +47,10 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/roadmap/skill-atoms/**").hasRole("ADMIN")
 
                 // Mixed access endpoints (roadmap operations)
-                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap").hasAnyRole("ADMIN", "LEARNER")
-                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap/start-progress").hasRole("LEARNER")
-                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap/complete-atom-progress").hasRole("LEARNER")
-                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap/recalculate-progress").hasAnyRole("ADMIN", "LEARNER")
+                .requestMatchers("/api/v1/roadmap").hasAnyRole("ADMIN", "LEARNER")
+                .requestMatchers("/api/v1/roadmap/start-progress").hasRole("LEARNER")
+                .requestMatchers("/api/v1/roadmap/complete-atom-progress").hasRole("LEARNER")
+                .requestMatchers("/api/v1/roadmap/recalculate-progress").hasAnyRole("ADMIN", "LEARNER")
 
                 // Learner-only endpoints (learner view)
                 .requestMatchers("/api/v1/learner/**").hasRole("LEARNER")

--- a/src/main/java/com/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.capstone.security.UserContextFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -40,8 +41,20 @@ public class SecurityConfig {
                 // Public endpoints - only actuator health
                 .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
 
-                // All other endpoints require authentication
-                .requestMatchers("/api/v1/roadmap/**").authenticated()
+                // Admin-only endpoints (roadmap management)
+                .requestMatchers("/api/v1/roadmap/talent-routes/**").hasAnyRole("ADMIN", "LEARNER")
+                .requestMatchers("/api/v1/roadmap/growth-tracks/**").hasRole("ADMIN")
+                .requestMatchers("/api/v1/roadmap/skill-capsules/**").hasRole("ADMIN")
+                .requestMatchers("/api/v1/roadmap/skill-atoms/**").hasRole("ADMIN")
+
+                // Mixed access endpoints (roadmap operations)
+                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap").hasAnyRole("ADMIN", "LEARNER")
+                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap/start-progress").hasRole("LEARNER")
+                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap/complete-atom-progress").hasRole("LEARNER")
+                .requestMatchers(HttpMethod.POST, "/api/v1/roadmap/recalculate-progress").hasAnyRole("ADMIN", "LEARNER")
+
+                // Learner-only endpoints (learner view)
+                .requestMatchers("/api/v1/learner/**").hasRole("LEARNER")
 
                 // Any other request requires authentication
                 .anyRequest().authenticated()

--- a/src/main/java/com/capstone/controller/LearnerRoadmapViewController.java
+++ b/src/main/java/com/capstone/controller/LearnerRoadmapViewController.java
@@ -1,0 +1,78 @@
+package com.capstone.controller;
+
+import com.capstone.dto.response.ApiResponseDto;
+import com.capstone.dto.response.LearnerAtomProgressDto;
+import com.capstone.dto.response.LearnerCapsuleProgressDto;
+import com.capstone.dto.response.LearnerRoadmapWithProgressDto;
+import com.capstone.dto.response.LearnerTrackProgressDto;
+import com.capstone.service.LearnerRoadmapService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/learner")
+@RequiredArgsConstructor
+@Tag(name = "Learner Roadmap View", description = "Learner-specific roadmap with progress")
+public class LearnerRoadmapViewController {
+
+    private final LearnerRoadmapService learnerRoadmapService;
+
+    @GetMapping("/my-roadmap")
+    @Operation(summary = "Get my roadmap with progress",
+               description = "Get learner's enrolled roadmap with basic progress info")
+    public ResponseEntity<ApiResponseDto<LearnerRoadmapWithProgressDto>> getMyRoadmap(
+            @RequestHeader("X-User-ID") UUID learnerId) {
+
+        Optional<LearnerRoadmapWithProgressDto> roadmap =
+            learnerRoadmapService.getLearnerRoadmap(learnerId);
+
+        return roadmap
+            .map(r -> ResponseEntity.ok(ApiResponseDto.success(r, "Your roadmap retrieved successfully")))
+            .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/my-tracks")
+    @Operation(summary = "Get my tracks with progress",
+               description = "Get all tracks for learner's roadmap with progress")
+    public ResponseEntity<ApiResponseDto<List<LearnerTrackProgressDto>>> getMyTracks(
+            @RequestHeader("X-User-ID") UUID learnerId) {
+
+        List<LearnerTrackProgressDto> tracks =
+            learnerRoadmapService.getLearnerTracks(learnerId);
+
+        return ResponseEntity.ok(ApiResponseDto.success(tracks, "Your tracks retrieved successfully"));
+    }
+
+    @GetMapping("/my-tracks/{trackId}/capsules")
+    @Operation(summary = "Get track capsules with progress",
+               description = "Get capsules for specific track with learner's progress")
+    public ResponseEntity<ApiResponseDto<List<LearnerCapsuleProgressDto>>> getTrackCapsules(
+            @PathVariable UUID trackId,
+            @RequestHeader("X-User-ID") UUID learnerId) {
+
+        List<LearnerCapsuleProgressDto> capsules =
+            learnerRoadmapService.getTrackCapsules(learnerId, trackId);
+
+        return ResponseEntity.ok(ApiResponseDto.success(capsules, "Track capsules retrieved successfully"));
+    }
+
+    @GetMapping("/my-capsules/{capsuleId}/atoms")
+    @Operation(summary = "Get capsule atoms with progress",
+               description = "Get atoms for specific capsule with learner's progress")
+    public ResponseEntity<ApiResponseDto<List<LearnerAtomProgressDto>>> getCapsuleAtoms(
+            @PathVariable UUID capsuleId,
+            @RequestHeader("X-User-ID") UUID learnerId) {
+
+        List<LearnerAtomProgressDto> atoms =
+            learnerRoadmapService.getCapsuleAtoms(learnerId, capsuleId);
+
+        return ResponseEntity.ok(ApiResponseDto.success(atoms, "Capsule atoms retrieved successfully"));
+    }
+}

--- a/src/main/java/com/capstone/dto/response/LearnerAtomProgressDto.java
+++ b/src/main/java/com/capstone/dto/response/LearnerAtomProgressDto.java
@@ -1,0 +1,28 @@
+package com.capstone.dto.response;
+
+import com.capstone.model.ProgressStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LearnerAtomProgressDto {
+    private UUID atomProgressId;
+    private UUID atomId;
+    private String name;
+    private String description;
+    private ProgressStatus status;
+    private boolean isCompleted;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+    private Boolean isUnlocked;
+}

--- a/src/main/java/com/capstone/dto/response/LearnerCapsuleProgressDto.java
+++ b/src/main/java/com/capstone/dto/response/LearnerCapsuleProgressDto.java
@@ -1,0 +1,29 @@
+package com.capstone.dto.response;
+
+import com.capstone.model.ProgressStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LearnerCapsuleProgressDto {
+    private UUID capsuleProgressId;
+    private UUID capsuleId;
+    private String capsuleName;
+    private String description;
+    private Integer sequenceOrder;
+    private ProgressStatus status;
+    private Integer progressPercentage;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+    private Boolean isUnlocked;
+}

--- a/src/main/java/com/capstone/dto/response/LearnerRoadmapWithProgressDto.java
+++ b/src/main/java/com/capstone/dto/response/LearnerRoadmapWithProgressDto.java
@@ -1,0 +1,27 @@
+package com.capstone.dto.response;
+
+import com.capstone.model.EnrollmentStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LearnerRoadmapWithProgressDto {
+    private UUID learnerId;
+    private UUID roadmapId;
+    private UUID talentRouteId;
+    private String routeName;
+    private String routeDescription;
+    private EnrollmentStatus enrollmentStatus;
+    private Integer overallProgressPercentage;
+    private LocalDateTime enrolledAt;
+}

--- a/src/main/java/com/capstone/dto/response/LearnerTrackProgressDto.java
+++ b/src/main/java/com/capstone/dto/response/LearnerTrackProgressDto.java
@@ -1,0 +1,29 @@
+package com.capstone.dto.response;
+
+import com.capstone.model.ProgressStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LearnerTrackProgressDto {
+    private UUID trackProgressId;
+    private UUID trackId;
+    private String trackName;
+    private String description;
+    private Integer sequenceOrder;
+    private ProgressStatus status;
+    private Integer progressPercentage;
+    private LocalDateTime startedAt;
+    private LocalDateTime completedAt;
+    private Boolean isUnlocked;
+}

--- a/src/main/java/com/capstone/mapper/LearnerRoadmapViewMapper.java
+++ b/src/main/java/com/capstone/mapper/LearnerRoadmapViewMapper.java
@@ -1,0 +1,60 @@
+package com.capstone.mapper;
+
+import com.capstone.dto.response.LearnerAtomProgressDto;
+import com.capstone.dto.response.LearnerCapsuleProgressDto;
+import com.capstone.dto.response.LearnerRoadmapWithProgressDto;
+import com.capstone.dto.response.LearnerTrackProgressDto;
+import com.capstone.model.LearnerAtomProgress;
+import com.capstone.model.LearnerCapsuleProgress;
+import com.capstone.model.LearnerRoadmap;
+import com.capstone.model.LearnerTrackProgress;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface LearnerRoadmapViewMapper {
+
+    // Main roadmap mapping
+    @Mapping(source = "userId", target = "learnerId")
+    @Mapping(source = "id", target = "roadmapId")
+    @Mapping(source = "talentRoute.talentRouteId", target = "talentRouteId")
+    @Mapping(source = "talentRoute.routeName", target = "routeName")
+    @Mapping(source = "talentRoute.description", target = "routeDescription")
+    @Mapping(source = "createdAt", target = "enrolledAt")
+    LearnerRoadmapWithProgressDto toLearnerRoadmapDto(LearnerRoadmap learnerRoadmap);
+
+    // Track progress mapping
+    @Mapping(source = "id", target = "trackProgressId")
+    @Mapping(source = "growthTrack.growthTrackId", target = "trackId")
+    @Mapping(source = "growthTrack.trackName", target = "trackName")
+    @Mapping(source = "growthTrack.description", target = "description")
+    @Mapping(target = "sequenceOrder", ignore = true)
+    @Mapping(target = "isUnlocked", ignore = true)
+    LearnerTrackProgressDto toLearnerTrackProgressDto(LearnerTrackProgress trackProgress);
+
+    List<LearnerTrackProgressDto> toLearnerTrackProgressDtoList(List<LearnerTrackProgress> trackProgresses);
+
+    // Capsule progress mapping
+    @Mapping(source = "id", target = "capsuleProgressId")
+    @Mapping(source = "skillCapsule.skillCapsuleId", target = "capsuleId")
+    @Mapping(source = "skillCapsule.capsuleName", target = "capsuleName")
+    @Mapping(source = "skillCapsule.description", target = "description")
+    @Mapping(target = "sequenceOrder", ignore = true)
+    @Mapping(target = "isUnlocked", ignore = true)
+    LearnerCapsuleProgressDto toLearnerCapsuleProgressDto(LearnerCapsuleProgress capsuleProgress);
+
+    List<LearnerCapsuleProgressDto> toLearnerCapsuleProgressDtoList(List<LearnerCapsuleProgress> capsuleProgresses);
+
+    // Atom progress mapping
+    @Mapping(source = "id", target = "atomProgressId")
+    @Mapping(source = "skillAtom.skillAtomId", target = "atomId")
+    @Mapping(source = "skillAtom.name", target = "name")
+    @Mapping(source = "skillAtom.description", target = "description")
+    @Mapping(source = "completed", target = "isCompleted")
+    @Mapping(target = "isUnlocked", ignore = true)
+    LearnerAtomProgressDto toLearnerAtomProgressDto(LearnerAtomProgress atomProgress);
+
+    List<LearnerAtomProgressDto> toLearnerAtomProgressDtoList(List<LearnerAtomProgress> atomProgresses);
+}

--- a/src/main/java/com/capstone/repository/LearnerCapsuleProgressRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerCapsuleProgressRepository.java
@@ -2,10 +2,29 @@ package com.capstone.repository;
 
 import com.capstone.model.LearnerCapsuleProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface LearnerCapsuleProgressRepository extends JpaRepository<LearnerCapsuleProgress, UUID> {
+
+    @Query("""
+        SELECT lap, cam.sequenceOrder FROM LearnerAtomProgress lap
+        JOIN lap.learnerCapsuleProgress lcp
+        JOIN lcp.learnerTrackProgress ltp
+        JOIN ltp.learnerRoadmap lr
+        JOIN CapsuleAtomMapping cam ON cam.skillAtom.id = lap.skillAtom.id
+            AND cam.skillCapsule.id = lcp.skillCapsule.id
+        WHERE lr.userId = :learnerId
+        AND lcp.skillCapsule.skillCapsuleId = :capsuleId
+        AND lr.enrollmentStatus = 'ACTIVE'
+        ORDER BY cam.sequenceOrder
+    """)
+    List<Object[]> findAtomProgressesByLearnerIdAndCapsuleIdWithSequence(
+        @Param("learnerId") UUID learnerId,
+        @Param("capsuleId") UUID capsuleId);
 }

--- a/src/main/java/com/capstone/repository/LearnerRoadmapRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerRoadmapRepository.java
@@ -20,4 +20,12 @@ public interface LearnerRoadmapRepository extends JpaRepository<LearnerRoadmap, 
     Optional<LearnerRoadmap> findByUserIdAndTalentRouteId(@Param("userId") UUID userId,
                                                           @Param("talentRouteId") UUID talentRouteId);
 
+    @Query("""
+        SELECT DISTINCT rm FROM LearnerRoadmap rm
+        LEFT JOIN FETCH rm.talentRoute tr
+        WHERE rm.userId = :learnerId
+        AND rm.enrollmentStatus = 'ACTIVE'
+    """)
+    Optional<LearnerRoadmap> findActiveRoadmapByUserId(@Param("learnerId") UUID learnerId);
+
 }

--- a/src/main/java/com/capstone/repository/LearnerTrackProgressRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerTrackProgressRepository.java
@@ -2,10 +2,39 @@ package com.capstone.repository;
 
 import com.capstone.model.LearnerTrackProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface LearnerTrackProgressRepository extends JpaRepository<LearnerTrackProgress, UUID> {
+
+    @Query("""
+        SELECT lcp, tcm.sequenceOrder FROM LearnerCapsuleProgress lcp
+        JOIN lcp.learnerTrackProgress ltp
+        JOIN ltp.learnerRoadmap lr
+        JOIN TrackCapsuleMapping tcm ON tcm.skillCapsule.id = lcp.skillCapsule.id
+            AND tcm.growthTrack.id = ltp.growthTrack.id
+        WHERE lr.userId = :learnerId
+        AND ltp.growthTrack.growthTrackId = :trackId
+        AND lr.enrollmentStatus = 'ACTIVE'
+        ORDER BY tcm.sequenceOrder
+    """)
+    List<Object[]> findCapsuleProgressesByLearnerIdAndTrackIdWithSequence(
+        @Param("learnerId") UUID learnerId,
+        @Param("trackId") UUID trackId);
+
+    @Query("""
+        SELECT ltp, rtm.sequenceOrder FROM LearnerTrackProgress ltp
+        JOIN ltp.learnerRoadmap lr
+        JOIN RouteTrackMapping rtm ON rtm.growthTrack.id = ltp.growthTrack.id
+            AND rtm.talentRoute.id = lr.talentRoute.id
+        WHERE lr.userId = :learnerId
+        AND lr.enrollmentStatus = 'ACTIVE'
+        ORDER BY rtm.sequenceOrder
+    """)
+    List<Object[]> findTrackProgressesByLearnerIdWithSequence(@Param("learnerId") UUID learnerId);
 }

--- a/src/main/java/com/capstone/service/LearnerRoadmapService.java
+++ b/src/main/java/com/capstone/service/LearnerRoadmapService.java
@@ -1,7 +1,20 @@
 package com.capstone.service;
 
+import com.capstone.dto.response.LearnerAtomProgressDto;
+import com.capstone.dto.response.LearnerCapsuleProgressDto;
+import com.capstone.dto.response.LearnerRoadmapWithProgressDto;
+import com.capstone.dto.response.LearnerTrackProgressDto;
 import com.capstone.dto.roadmap.RoadmapRequestDto;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface LearnerRoadmapService {
     void assignLearnerToTalentRoute(RoadmapRequestDto roadmapRequestDto);
+
+    Optional<LearnerRoadmapWithProgressDto> getLearnerRoadmap(UUID learnerId);
+    List<LearnerTrackProgressDto> getLearnerTracks(UUID learnerId);
+    List<LearnerCapsuleProgressDto> getTrackCapsules(UUID learnerId, UUID trackId);
+    List<LearnerAtomProgressDto> getCapsuleAtoms(UUID learnerId, UUID capsuleId);
 }

--- a/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
@@ -1,9 +1,17 @@
 package com.capstone.service.impl;
 
 import com.capstone.dto.roadmap.RoadmapRequestDto;
+import com.capstone.dto.response.LearnerAtomProgressDto;
+import com.capstone.dto.response.LearnerCapsuleProgressDto;
+import com.capstone.dto.response.LearnerRoadmapWithProgressDto;
+import com.capstone.dto.response.LearnerTrackProgressDto;
+import com.capstone.exception.GrowthTrackNotFoundException;
 import com.capstone.exception.RoadmapExistException;
+import com.capstone.exception.RoadmapNotFoundException;
+import com.capstone.exception.SkillCapsuleNotFoundException;
 import com.capstone.exception.TalentRouteNotFoundException;
 import com.capstone.exception.UserNotFoundException;
+import com.capstone.mapper.LearnerRoadmapViewMapper;
 import com.capstone.model.*;
 import com.capstone.repository.*;
 import com.capstone.service.LearnerRoadmapService;
@@ -12,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -23,6 +32,11 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
     private final RouteTrackMappingRepository routeTrackMappingRepository;
     private final GrowthTrackCapsuleMappingRepository growthTrackCapsuleMappingRepository;
     private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
+
+    // New dependencies for learner view methods
+    private final LearnerTrackProgressRepository learnerTrackProgressRepository;
+    private final LearnerCapsuleProgressRepository learnerCapsuleProgressRepository;
+    private final LearnerRoadmapViewMapper mapper;
 
     @Transactional
     @Override
@@ -131,5 +145,147 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
                 )
                 .toList();
 
+    }
+
+    // Learner view methods implementation
+    @Override
+    public Optional<LearnerRoadmapWithProgressDto> getLearnerRoadmap(UUID learnerId) {
+        return learnerRoadmapRepository.findActiveRoadmapByUserId(learnerId)
+            .map(mapper::toLearnerRoadmapDto);
+    }
+
+    @Override
+    public List<LearnerTrackProgressDto> getLearnerTracks(UUID learnerId) {
+        // Validate learner has active roadmap first
+        if (learnerRoadmapRepository.findActiveRoadmapByUserId(learnerId).isPresent()) {
+            List<Object[]> trackProgressesWithSequence =
+                    learnerTrackProgressRepository.findTrackProgressesByLearnerIdWithSequence(learnerId);
+
+            return trackProgressesWithSequence.stream()
+                .map(result -> {
+                    LearnerTrackProgress trackProgress = (LearnerTrackProgress) result[0];
+                    Integer sequenceOrder = (Integer) result[1];
+
+                    LearnerTrackProgressDto dto = mapper.toLearnerTrackProgressDto(trackProgress);
+                    dto.setSequenceOrder(sequenceOrder);
+
+                    // Set unlock status: first track is always unlocked, others depend on previous completion
+                    dto.setIsUnlocked(sequenceOrder == 1 || isPreviousTrackCompleted(learnerId, sequenceOrder));
+
+                    return dto;
+                })
+                .toList();
+        } else {
+            throw new RoadmapNotFoundException("No active roadmap found for learner: " + learnerId);
+        }
+    }
+
+    @Override
+    public List<LearnerCapsuleProgressDto> getTrackCapsules(UUID learnerId, UUID trackId) {
+        // Validate learner has active roadmap
+        if (learnerRoadmapRepository.findActiveRoadmapByUserId(learnerId).isEmpty()) {
+            throw new RoadmapNotFoundException("No active roadmap found for learner: " + learnerId);
+        }
+
+        List<Object[]> capsuleProgressesWithSequence =
+            learnerTrackProgressRepository.findCapsuleProgressesByLearnerIdAndTrackIdWithSequence(learnerId, trackId);
+
+        // If empty, track might not exist or not belong to learner
+        if (capsuleProgressesWithSequence.isEmpty()) {
+            throw new GrowthTrackNotFoundException("Track not found or not accessible for learner", trackId);
+        }
+
+        return capsuleProgressesWithSequence.stream()
+            .map(result -> {
+                LearnerCapsuleProgress capsuleProgress = (LearnerCapsuleProgress) result[0];
+                Integer sequenceOrder = (Integer) result[1];
+
+                LearnerCapsuleProgressDto dto = mapper.toLearnerCapsuleProgressDto(capsuleProgress);
+                dto.setSequenceOrder(sequenceOrder);
+
+                // Set unlock status: first capsule is always unlocked, others depend on previous completion
+                dto.setIsUnlocked(sequenceOrder == 1 || isPreviousCapsuleCompleted(learnerId, trackId, sequenceOrder));
+
+                return dto;
+            })
+            .toList();
+    }
+
+    @Override
+    public List<LearnerAtomProgressDto> getCapsuleAtoms(UUID learnerId, UUID capsuleId) {
+        // Validate learner has active roadmap
+        if (learnerRoadmapRepository.findActiveRoadmapByUserId(learnerId).isEmpty()) {
+            throw new RoadmapNotFoundException("No active roadmap found for learner: " + learnerId);
+        }
+
+        List<Object[]> atomProgressesWithSequence =
+            learnerCapsuleProgressRepository.findAtomProgressesByLearnerIdAndCapsuleIdWithSequence(learnerId, capsuleId);
+
+        // If empty, capsule might not exist or not belong to learner
+        if (atomProgressesWithSequence.isEmpty()) {
+            throw new SkillCapsuleNotFoundException("Capsule not found or not accessible for learner", capsuleId);
+        }
+
+        return atomProgressesWithSequence.stream()
+            .map(result -> {
+                LearnerAtomProgress atomProgress = (LearnerAtomProgress) result[0];
+                Integer sequenceOrder = (Integer) result[1];
+
+                LearnerAtomProgressDto dto = mapper.toLearnerAtomProgressDto(atomProgress);
+
+                // Set unlock status: first atom is always unlocked, others depend on previous completion
+                dto.setIsUnlocked(sequenceOrder == 1 || isPreviousAtomCompleted(learnerId, capsuleId, sequenceOrder));
+
+                return dto;
+            })
+            .toList();
+    }
+
+    // Helper methods for unlock logic
+    private boolean isPreviousTrackCompleted(UUID learnerId, Integer currentSequence) {
+        if (currentSequence <= 1) return true;
+
+        List<Object[]> allTracks = learnerTrackProgressRepository.findTrackProgressesByLearnerIdWithSequence(learnerId);
+
+        return allTracks.stream()
+            .filter(result -> result[1].equals(currentSequence - 1))
+            .findFirst()
+            .map(result -> {
+                LearnerTrackProgress previousTrack = (LearnerTrackProgress) result[0];
+                return previousTrack.getStatus() == ProgressStatus.COMPLETED;
+            })
+            .orElse(false);
+    }
+
+    private boolean isPreviousCapsuleCompleted(UUID learnerId, UUID trackId, Integer currentSequence) {
+        if (currentSequence <= 1) return true;
+
+        List<Object[]> allCapsules = learnerTrackProgressRepository
+            .findCapsuleProgressesByLearnerIdAndTrackIdWithSequence(learnerId, trackId);
+
+        return allCapsules.stream()
+            .filter(result -> result[1].equals(currentSequence - 1))
+            .findFirst()
+            .map(result -> {
+                LearnerCapsuleProgress previousCapsule = (LearnerCapsuleProgress) result[0];
+                return previousCapsule.getStatus() == ProgressStatus.COMPLETED;
+            })
+            .orElse(false);
+    }
+
+    private boolean isPreviousAtomCompleted(UUID learnerId, UUID capsuleId, Integer currentSequence) {
+        if (currentSequence <= 1) return true;
+
+        List<Object[]> allAtoms = learnerCapsuleProgressRepository
+            .findAtomProgressesByLearnerIdAndCapsuleIdWithSequence(learnerId, capsuleId);
+
+        return allAtoms.stream()
+            .filter(result -> result[1].equals(currentSequence - 1))
+            .findFirst()
+            .map(result -> {
+                LearnerAtomProgress previousAtom = (LearnerAtomProgress) result[0];
+                return previousAtom.isCompleted();
+            })
+            .orElse(false);
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request: Learner Roadmap Progress Endpoints with  Unlock Logic

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-20: Add Learner-Specific Roadmap Views with Sequential Unlock Logic](https://amali-tech.atlassian.net/browse/VER-118)

---

## ✅ Summary

  - Implemented learner-specific roadmap viewing system with progressive unlock functionality
  - Added role-based access control to differentiate admin and learner endpoints
  - Created sequence-based unlock logic using real sequence order from mapping tables

---

## 📌 Key Features
  - Learner Roadmap Views: new endpoints for learners to view their personalized roadmap progress
  - Sequential Unlock Logic: Progressive learning system where items unlock based on completion of previous items
  - Role-Based Security: Proper endpoint segregation between admin management and learner access
  - Real Sequence Order: Unlock logic based on actual sequence from RouteTrackMapping, TrackCapsuleMapping, and CapsuleAtomMapping tables
