### PR TITLE
Feat: Kafka Integration VER-152

### DIFF
--- a/src/main/java/com/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/roadmap/recalculate-progress").hasAnyRole("ADMIN", "LEARNER")
 
                 // Learner-only endpoints (learner view)
-                .requestMatchers("/api/v1/learner/**").hasRole("LEARNER")
+                .requestMatchers("/api/v1/learner/**").hasAnyRole("ADMIN","LEARNER")
 
                 // Any other request requires authentication
                 .anyRequest().authenticated()

--- a/src/main/java/com/capstone/exception/TalentRouteNotFoundException.java
+++ b/src/main/java/com/capstone/exception/TalentRouteNotFoundException.java
@@ -1,7 +1,12 @@
 package com.capstone.exception;
 
+import java.util.UUID;
+
 public class TalentRouteNotFoundException extends RuntimeException {
     public TalentRouteNotFoundException(String message) {
         super(message);
+    }
+    public TalentRouteNotFoundException(UUID routeId) {
+        super("Talent route not found with ID: " + routeId);
     }
 }

--- a/src/main/java/com/capstone/messaging/AtomKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/AtomKafkaConsumer.java
@@ -110,4 +110,44 @@ public class AtomKafkaConsumer {
                     atomId, dltException);
         }
     }
+
+    @KafkaListener(topics = "${KAFKA_ATOM_UPDATE_TOPIC:atom.update}")
+    @Retryable(
+            retryFor = {SkillAtomProcessingException.class, Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenAtomUpdate(
+            @Payload SkillAtomEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received atom.update event from topic: {}, partition: {}, offset: {}, atomId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate event
+            validateSkillAtomEvent(event);
+
+            // Process the skill atom update using existing service logic
+            SkillAtomSnapshot updatedAtom = skillAtomSnapshotService.processSkillAtomEvent(event);
+
+            log.info("Successfully updated skill atom for atomId: {}, internal ID: {}",
+                    event.getId(), updatedAtom.getId());
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (SkillAtomProcessingException e) {
+            log.error("Failed to update skill atom for atomId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+
+        } catch (Exception e) {
+            log.error("Unexpected error updating skill atom for atomId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment);
+        }
+    }
 }

--- a/src/main/java/com/capstone/messaging/CapsuleKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/CapsuleKafkaConsumer.java
@@ -2,6 +2,7 @@ package com.capstone.messaging;
 
 import com.capstone.exception.CapsuleAtomMappingException;
 import com.capstone.exception.SkillAtomNotFoundException;
+import com.capstone.exception.SkillCapsuleNotFoundException;
 import com.capstone.exception.SkillCapsuleProcessingException;
 import com.capstone.model.SkillCapsuleSnapshot;
 import com.capstone.service.SkillCapsuleSnapshotService;
@@ -63,22 +64,22 @@ public class CapsuleKafkaConsumer {
         } catch (SkillCapsuleProcessingException e) {
             log.error("Failed to process skill capsule event for capsuleId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment,"CREATE");
 
         } catch (CapsuleAtomMappingException e) {
             log.error("Failed to process capsule-atom mappings for capsuleId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment,"CREATE");
 
         } catch (SkillAtomNotFoundException e) {
             log.error("Missing skill atom reference for capsuleId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment,"CREATE");
 
         } catch (Exception e) {
             log.error("Unexpected error processing skill capsule event for capsuleId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment,"CREATE");
         }
     }
 
@@ -180,20 +181,30 @@ public class CapsuleKafkaConsumer {
     /**
      * Handle processing failures with DLT support
      */
-    private void handleProcessingFailure(SkillCapsuleEvent event, Acknowledgment acknowledgment) {
+    private void handleProcessingFailure(SkillCapsuleEvent event, Acknowledgment acknowledgment, String operationType) {
         String capsuleId = event.getId().toString();
 
-        log.error("Processing failed for skill capsule event with capsuleId: {}. Sending to DLT topic: {}",
-                capsuleId, capsuleDltTopic);
+        log.error("Processing failed for skill capsule {} operation with capsuleId: {}. Sending to DLT topic: {}",
+                operationType, capsuleId, capsuleDltTopic);
 
         try {
-            // Send to Dead Letter Topic for manual review/reprocessing - O(1)
-            kafkaTemplate.send(capsuleDltTopic, capsuleId, event)
+            // Create enhanced event with operation type for DLT analysis
+            Map<String, Object> dltPayload = Map.of(
+                    "originalEvent", event,
+                    "operationType", operationType,
+                    "failureTimestamp", System.currentTimeMillis(),
+                    "capsuleId", capsuleId
+            );
+
+            // Send to Dead Letter Topic for manual review/reprocessing
+            kafkaTemplate.send(capsuleDltTopic, capsuleId, dltPayload)
                     .whenComplete((result, ex) -> {
                         if (ex == null) {
-                            log.info("Successfully sent failed skill capsule event to DLT for capsuleId: {}", capsuleId);
+                            log.info("Successfully sent failed skill capsule {} event to DLT for capsuleId: {}",
+                                    operationType, capsuleId);
                         } else {
-                            log.error("Failed to send skill capsule event to DLT for capsuleId: {}", capsuleId, ex);
+                            log.error("Failed to send skill capsule {} event to DLT for capsuleId: {}",
+                                    operationType, capsuleId, ex);
                         }
                     });
 
@@ -201,8 +212,138 @@ public class CapsuleKafkaConsumer {
             acknowledgment.acknowledge();
 
         } catch (Exception dltException) {
-            log.error("Critical: Failed to send skill capsule message to DLT for capsuleId: {}. Message will be retried by Kafka",
-                    capsuleId, dltException);
+            log.error("Critical: Failed to send skill capsule {} message to DLT for capsuleId: {}. Message will be retried by Kafka",
+                    operationType, capsuleId, dltException);
         }
     }
+
+    @KafkaListener(topics = "${KAFKA_CAPSULE_UPDATE_TOPIC:capsule.update}")
+    @Retryable(
+            retryFor = {SkillCapsuleProcessingException.class, CapsuleAtomMappingException.class, Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenCapsuleUpdate(
+            @Payload SkillCapsuleEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received capsule.update event from topic: {}, partition: {}, offset: {}, capsuleId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate event
+            validateSkillCapsuleEvent(event);
+
+            // Process the skill capsule update using existing service logic
+            SkillCapsuleSnapshot updatedCapsule = skillCapsuleSnapshotService.processSkillCapsuleEvent(event);
+
+            log.info("Successfully updated skill capsule for capsuleId: {}, internal ID: {}, atoms: {}",
+                    event.getId(), updatedCapsule.getId(),
+                    event.getSkillAtom() != null ? event.getSkillAtom().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (SkillCapsuleProcessingException e) {
+            log.error("Failed to update skill capsule for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (CapsuleAtomMappingException e) {
+            log.error("Failed to update capsule-atom mappings for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (SkillAtomNotFoundException e) {
+            log.error("Missing skill atom reference during capsule update for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (Exception e) {
+            log.error("Unexpected error updating skill capsule for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+        }
+    }
+
+    @KafkaListener(topics = "${KAFKA_CAPSULE_ASSIGN_TOPIC:capsule.assign}")
+    @Retryable(
+            retryFor = {SkillCapsuleProcessingException.class, CapsuleAtomMappingException.class, SkillAtomNotFoundException.class,
+                    Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenCapsuleAssign(
+            @Payload SkillCapsuleEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received capsule.assign event from topic: {}, partition: {}, offset: {}, capsuleId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate capsule exists
+            validateCapsuleAssignEvent(event);
+
+            // Process atom assignment to existing capsule
+            SkillCapsuleSnapshot updatedCapsule = skillCapsuleSnapshotService.assignAtomsToCapsule(event);
+
+            log.info("Successfully assigned atoms to capsule for capsuleId: {}, internal ID: {}, atoms: {}",
+                    event.getId(), updatedCapsule.getId(),
+                    event.getSkillAtom() != null ? event.getSkillAtom().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (SkillCapsuleNotFoundException e) {
+            log.error("Capsule not found for assignment, capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (CapsuleAtomMappingException e) {
+            log.error("Failed to assign capsule-atom mappings for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (SkillAtomNotFoundException e) {
+            log.error("Missing skill atom reference during capsule assignment for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (Exception e) {
+            log.error("Unexpected error assigning atoms to capsule for capsuleId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+        }
+    }
+
+    /**
+     * Validate capsule.assign event - focuses on atom mappings only
+     */
+    private void validateCapsuleAssignEvent(SkillCapsuleEvent event) {
+        log.debug("Validating capsule.assign event: {}", event);
+
+        // Basic event validation
+        if (event == null) {
+            throw new SkillCapsuleProcessingException("Capsule assign event cannot be null");
+        }
+
+        if (event.getId() == null) {
+            throw new SkillCapsuleProcessingException("Capsule assign event must contain a valid capsule ID");
+        }
+
+        // For assign operation, skillAtom mappings are required
+        if (event.getSkillAtom() == null || event.getSkillAtom().isEmpty()) {
+            throw new CapsuleAtomMappingException("Capsule assign event must contain at least one skill atom mapping");
+        }
+
+        // Validate atom mappings structure
+        validateSkillAtomMappings(event.getSkillAtom(), event.getId());
+
+        log.debug("Capsule assign event validation successful for capsuleId: {}", event.getId());
+    }
+
 }

--- a/src/main/java/com/capstone/messaging/GrowthTrackKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/GrowthTrackKafkaConsumer.java
@@ -1,5 +1,6 @@
 package com.capstone.messaging;
 
+import com.capstone.exception.GrowthTrackNotFoundException;
 import com.capstone.exception.GrowthTrackProcessingException;
 import com.capstone.exception.SkillCapsuleNotFoundException;
 import com.capstone.exception.TrackCapsuleMappingException;
@@ -68,22 +69,22 @@ public class GrowthTrackKafkaConsumer {
         } catch (GrowthTrackProcessingException e) {
             log.error("Failed to process growth track event for trackId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
 
         } catch (TrackCapsuleMappingException e) {
             log.error("Failed to process track-capsule mappings for trackId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
 
         } catch (SkillCapsuleNotFoundException e) {
             log.error("Missing skill capsule reference for trackId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
 
         } catch (Exception e) {
             log.error("Unexpected error processing growth track event for trackId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
         }
     }
 
@@ -172,20 +173,30 @@ public class GrowthTrackKafkaConsumer {
     /**
      * Handle processing failures with DLT support
      */
-    private void handleProcessingFailure(GrowthTrackEvent event, Acknowledgment acknowledgment) {
+    private void handleProcessingFailure(GrowthTrackEvent event, Acknowledgment acknowledgment, String operationType) {
         String trackId = event.getId().toString();
 
-        log.error("Processing failed for growth track event with trackId: {}. Sending to DLT topic: {}",
-                trackId, growthTrackDltTopic);
+        log.error("Processing failed for growth track {} operation with trackId: {}. Sending to DLT topic: {}",
+                operationType, trackId, growthTrackDltTopic);
 
         try {
+            // Create enhanced event with operation type for DLT analysis
+            Map<String, Object> dltPayload = Map.of(
+                    "originalEvent", event,
+                    "operationType", operationType,
+                    "failureTimestamp", System.currentTimeMillis(),
+                    "trackId", trackId
+            );
+
             // Send to Dead Letter Topic for manual review/reprocessing
-            kafkaTemplate.send(growthTrackDltTopic, trackId, event)
+            kafkaTemplate.send(growthTrackDltTopic, trackId, dltPayload)
                     .whenComplete((result, ex) -> {
                         if (ex == null) {
-                            log.info("Successfully sent failed growth track event to DLT for trackId: {}", trackId);
+                            log.info("Successfully sent failed growth track {} event to DLT for trackId: {}",
+                                    operationType, trackId);
                         } else {
-                            log.error("Failed to send growth track event to DLT for trackId: {}", trackId, ex);
+                            log.error("Failed to send growth track {} event to DLT for trackId: {}",
+                                    operationType, trackId, ex);
                         }
                     });
 
@@ -193,8 +204,138 @@ public class GrowthTrackKafkaConsumer {
             acknowledgment.acknowledge();
 
         } catch (Exception dltException) {
-            log.error("Critical: Failed to send growth track message to DLT for trackId: {}. Message will be retried by Kafka",
-                    trackId, dltException);
+            log.error("Critical: Failed to send growth track {} message to DLT for trackId: {}. Message will be retried by Kafka",
+                    operationType, trackId, dltException);
         }
+    }
+
+    @KafkaListener(topics = "${KAFKA_GROWTH_TRACK_UPDATE_TOPIC:growthTrack.update}")
+    @Retryable(
+            retryFor = {GrowthTrackProcessingException.class, TrackCapsuleMappingException.class, SkillCapsuleNotFoundException.class,
+                    Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenGrowthTrackUpdate(
+            @Payload GrowthTrackEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received growthTrack.update event from topic: {}, partition: {}, offset: {}, trackId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate event
+            validateGrowthTrackEvent(event);
+
+            // Process the growth track update using existing service logic
+            GrowthTrackSnapshot updatedTrack = growthTrackSnapshotService.processGrowthTrackEvent(event);
+
+            log.info("Successfully updated growth track for trackId: {}, internal ID: {}, capsules: {}",
+                    event.getId(), updatedTrack.getId(),
+                    event.getSkillCapsules() != null ? event.getSkillCapsules().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (GrowthTrackProcessingException e) {
+            log.error("Failed to update growth track for trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (TrackCapsuleMappingException e) {
+            log.error("Failed to update track-capsule mappings for trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (SkillCapsuleNotFoundException e) {
+            log.error("Missing skill capsule reference during track update for trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (Exception e) {
+            log.error("Unexpected error updating growth track for trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+        }
+    }
+
+    @KafkaListener(topics = "${KAFKA_GROWTH_TRACK_ASSIGN_TOPIC:growthTrack.assign}")
+    @Retryable(
+            retryFor = {GrowthTrackProcessingException.class, TrackCapsuleMappingException.class, SkillCapsuleNotFoundException.class,
+                    Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenGrowthTrackAssign(
+            @Payload GrowthTrackEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received growthTrack.assign event from topic: {}, partition: {}, offset: {}, trackId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate growth track assign event
+            validateGrowthTrackAssignEvent(event);
+
+            // Process capsule assignment to existing growth track
+            GrowthTrackSnapshot updatedTrack = growthTrackSnapshotService.assignCapsulesToTrack(event);
+
+            log.info("Successfully assigned capsules to growth track for trackId: {}, internal ID: {}, capsules: {}",
+                    event.getId(), updatedTrack.getId(),
+                    event.getSkillCapsules() != null ? event.getSkillCapsules().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (GrowthTrackNotFoundException e) {
+            log.error("Growth track not found for assignment, trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (TrackCapsuleMappingException e) {
+            log.error("Failed to assign track-capsule mappings for trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (SkillCapsuleNotFoundException e) {
+            log.error("Missing skill capsule reference during track assignment for trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (Exception e) {
+            log.error("Unexpected error assigning capsules to growth track for trackId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+        }
+    }
+
+    /**
+     * Validate growthTrack.assign event - focuses on capsule mappings only
+     */
+    private void validateGrowthTrackAssignEvent(GrowthTrackEvent event) {
+        log.debug("Validating growthTrack.assign event: {}", event);
+
+        // Basic event validation
+        if (event == null) {
+            throw new GrowthTrackProcessingException("Growth track assign event cannot be null");
+        }
+
+        if (event.getId() == null) {
+            throw new GrowthTrackProcessingException("Growth track assign event must contain a valid track ID");
+        }
+
+        // For assign operation, skillCapsules mappings are required
+        if (event.getSkillCapsules() == null || event.getSkillCapsules().isEmpty()) {
+            throw new TrackCapsuleMappingException("Growth track assign event must contain at least one skill capsule mapping");
+        }
+
+        // Validate capsule mappings structure
+        validateSkillCapsuleMappings(event.getSkillCapsules(), event.getId());
+
+        log.debug("Growth track assign event validation successful for trackId: {}", event.getId());
     }
 }

--- a/src/main/java/com/capstone/messaging/TalentRouteKafkaConsumer.java
+++ b/src/main/java/com/capstone/messaging/TalentRouteKafkaConsumer.java
@@ -2,6 +2,7 @@ package com.capstone.messaging;
 
 import com.capstone.exception.GrowthTrackNotFoundException;
 import com.capstone.exception.RouteTrackMappingException;
+import com.capstone.exception.TalentRouteNotFoundException;
 import com.capstone.exception.TalentRouteProcessingException;
 import com.capstone.model.TalentRouteSnapshot;
 import com.capstone.service.TalentRouteSnapshotService;
@@ -68,22 +69,22 @@ public class TalentRouteKafkaConsumer {
         } catch (TalentRouteProcessingException e) {
             log.error("Failed to process talent route event for routeId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
 
         } catch (RouteTrackMappingException e) {
             log.error("Failed to process route-track mappings for routeId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
 
         } catch (GrowthTrackNotFoundException e) {
             log.error("Missing growth track reference for routeId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
 
         } catch (Exception e) {
             log.error("Unexpected error processing talent route event for routeId: {}. Error: {}",
                     event.getId(), e.getMessage(), e);
-            handleProcessingFailure(event, acknowledgment);
+            handleProcessingFailure(event, acknowledgment, "CREATE");
         }
     }
 
@@ -172,20 +173,30 @@ public class TalentRouteKafkaConsumer {
     /**
      * Handle processing failures with DLT support
      */
-    private void handleProcessingFailure(TalentRouteEvent event, Acknowledgment acknowledgment) {
+    private void handleProcessingFailure(TalentRouteEvent event, Acknowledgment acknowledgment, String operationType) {
         String routeId = event.getId().toString();
 
-        log.error("Processing failed for talent route event with routeId: {}. Sending to DLT topic: {}",
-                routeId, talentRouteDltTopic);
+        log.error("Processing failed for talent route {} operation with routeId: {}. Sending to DLT topic: {}",
+                operationType, routeId, talentRouteDltTopic);
 
         try {
+            // Create enhanced event with operation type for DLT analysis
+            Map<String, Object> dltPayload = Map.of(
+                    "originalEvent", event,
+                    "operationType", operationType,
+                    "failureTimestamp", System.currentTimeMillis(),
+                    "routeId", routeId
+            );
+
             // Send to Dead Letter Topic for manual review/reprocessing
-            kafkaTemplate.send(talentRouteDltTopic, routeId, event)
+            kafkaTemplate.send(talentRouteDltTopic, routeId, dltPayload)
                     .whenComplete((result, ex) -> {
                         if (ex == null) {
-                            log.info("Successfully sent failed talent route event to DLT for routeId: {}", routeId);
+                            log.info("Successfully sent failed talent route {} event to DLT for routeId: {}",
+                                    operationType, routeId);
                         } else {
-                            log.error("Failed to send talent route event to DLT for routeId: {}", routeId, ex);
+                            log.error("Failed to send talent route {} event to DLT for routeId: {}",
+                                    operationType, routeId, ex);
                         }
                     });
 
@@ -193,8 +204,138 @@ public class TalentRouteKafkaConsumer {
             acknowledgment.acknowledge();
 
         } catch (Exception dltException) {
-            log.error("Critical: Failed to send talent route message to DLT for routeId: {}. Message will be retried by Kafka",
-                    routeId, dltException);
+            log.error("Critical: Failed to send talent route {} message to DLT for routeId: {}. Message will be retried by Kafka",
+                    operationType, routeId, dltException);
         }
+    }
+
+    @KafkaListener(topics = "${KAFKA_TALENT_ROUTE_UPDATE_TOPIC:talentRoute.update}")
+    @Retryable(
+            retryFor = {TalentRouteProcessingException.class, RouteTrackMappingException.class, GrowthTrackNotFoundException.class,
+                    Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenTalentRouteUpdate(
+            @Payload TalentRouteEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received talentRoute.update event from topic: {}, partition: {}, offset: {}, routeId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate event
+            validateTalentRouteEvent(event);
+
+            // Process the talent route update using existing service logic
+            TalentRouteSnapshot updatedRoute = talentRouteSnapshotService.processTalentRouteEvent(event);
+
+            log.info("Successfully updated talent route for routeId: {}, internal ID: {}, tracks: {}",
+                    event.getId(), updatedRoute.getId(),
+                    event.getGrowthTracks() != null ? event.getGrowthTracks().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (TalentRouteProcessingException e) {
+            log.error("Failed to update talent route for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (RouteTrackMappingException e) {
+            log.error("Failed to update route-track mappings for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (GrowthTrackNotFoundException e) {
+            log.error("Missing growth track reference during route update for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+
+        } catch (Exception e) {
+            log.error("Unexpected error updating talent route for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "UPDATE");
+        }
+    }
+
+    @KafkaListener(topics = "${KAFKA_TALENT_ROUTE_ASSIGN_TOPIC:talentRoute.assign}")
+    @Retryable(
+            retryFor = {TalentRouteProcessingException.class, RouteTrackMappingException.class, GrowthTrackNotFoundException.class,
+                    Exception.class},
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void listenTalentRouteAssign(
+            @Payload TalentRouteEvent event,
+            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+            @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+            @Header(KafkaHeaders.OFFSET) long offset,
+            Acknowledgment acknowledgment) {
+
+        log.info("Received talentRoute.assign event from topic: {}, partition: {}, offset: {}, routeId: {}",
+                topic, partition, offset, event.getId());
+
+        try {
+            // Validate talent route assign event
+            validateTalentRouteAssignEvent(event);
+
+            // Process track assignment to existing talent route
+            TalentRouteSnapshot updatedRoute = talentRouteSnapshotService.assignTracksToRoute(event);
+
+            log.info("Successfully assigned tracks to talent route for routeId: {}, internal ID: {}, tracks: {}",
+                    event.getId(), updatedRoute.getId(),
+                    event.getGrowthTracks() != null ? event.getGrowthTracks().size() : 0);
+
+            // Acknowledge message only after successful processing
+            acknowledgment.acknowledge();
+
+        } catch (TalentRouteNotFoundException e) {
+            log.error("Talent route not found for assignment, routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (RouteTrackMappingException e) {
+            log.error("Failed to assign route-track mappings for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (GrowthTrackNotFoundException e) {
+            log.error("Missing growth track reference during route assignment for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+
+        } catch (Exception e) {
+            log.error("Unexpected error assigning tracks to talent route for routeId: {}. Error: {}",
+                    event.getId(), e.getMessage(), e);
+            handleProcessingFailure(event, acknowledgment, "ASSIGN");
+        }
+    }
+
+    /**
+     * Validate talentRoute.assign event - focuses on track mappings only
+     */
+    private void validateTalentRouteAssignEvent(TalentRouteEvent event) {
+        log.debug("Validating talentRoute.assign event: {}", event);
+
+        // Basic event validation
+        if (event == null) {
+            throw new TalentRouteProcessingException("Talent route assign event cannot be null");
+        }
+
+        if (event.getId() == null) {
+            throw new TalentRouteProcessingException("Talent route assign event must contain a valid route ID");
+        }
+
+        // For assign operation, growthTracks mappings are required
+        if (event.getGrowthTracks() == null || event.getGrowthTracks().isEmpty()) {
+            throw new RouteTrackMappingException("Talent route assign event must contain at least one growth track mapping");
+        }
+
+        // Validate track mappings structure
+        validateGrowthTrackMappings(event.getGrowthTracks(), event.getId());
+
+        log.debug("Talent route assign event validation successful for routeId: {}", event.getId());
     }
 }

--- a/src/main/java/com/capstone/service/GrowthTrackSnapshotService.java
+++ b/src/main/java/com/capstone/service/GrowthTrackSnapshotService.java
@@ -17,8 +17,7 @@ public interface GrowthTrackSnapshotService {
     GrowthTrackSnapshot updateGrowthTrack(GrowthTrackSnapshot existingTrack, GrowthTrackEvent event);
     void smartUpdateTrackCapsuleMappings(GrowthTrackSnapshot track, List<Map<UUID, Integer>> skillCapsuleMappings);
     Optional<GrowthTrackSnapshot> findByGrowthTrackId(UUID growthTrackId);
-    boolean existsByGrowthTrackId(UUID growthTrackId);
-    Optional<GrowthTrackSnapshot> findByGrowthTrackIdWithCapsuleMappings(UUID growthTrackId);
+    GrowthTrackSnapshot  assignCapsulesToTrack(GrowthTrackEvent event);
 
 
     PaginatedResponseDto<GrowthTrackResponseDto> findAllBasic(Pageable pageable);

--- a/src/main/java/com/capstone/service/SkillCapsuleSnapshotService.java
+++ b/src/main/java/com/capstone/service/SkillCapsuleSnapshotService.java
@@ -13,16 +13,13 @@ import java.util.UUID;
 
 public interface SkillCapsuleSnapshotService {
 
-    // ===== EXISTING KAFKA/PROCESSING METHODS =====
     SkillCapsuleSnapshot processSkillCapsuleEvent(SkillCapsuleEvent event);
     SkillCapsuleSnapshot createSkillCapsule(SkillCapsuleEvent event);
     SkillCapsuleSnapshot updateSkillCapsule(SkillCapsuleSnapshot existingCapsule, SkillCapsuleEvent event);
     void smartUpdateCapsuleAtomMappings(SkillCapsuleSnapshot capsule, List<Map<UUID, Integer>> skillAtomMappings);
     Optional<SkillCapsuleSnapshot> findBySkillCapsuleId(UUID skillCapsuleId);
-    boolean existsBySkillCapsuleId(UUID skillCapsuleId);
-    Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(UUID skillCapsuleId);
+    SkillCapsuleSnapshot assignAtomsToCapsule(SkillCapsuleEvent event);
 
-    // ===== NEW CLEAN DTO-BASED METHODS =====
     PaginatedResponseDto<SkillCapsuleResponseDto> findAllBasic(Pageable pageable);
     PaginatedResponseDto<SkillCapsuleResponseDto> findAllWithAtomSummaries(Pageable pageable);
     PaginatedResponseDto<SkillCapsuleResponseDto> searchByCapsuleNameBasic(String capsuleName, Pageable pageable);

--- a/src/main/java/com/capstone/service/TalentRouteSnapshotService.java
+++ b/src/main/java/com/capstone/service/TalentRouteSnapshotService.java
@@ -16,6 +16,7 @@ public interface TalentRouteSnapshotService {
     TalentRouteSnapshot createTalentRoute(TalentRouteEvent event);
     TalentRouteSnapshot updateTalentRoute(TalentRouteSnapshot existingRoute, TalentRouteEvent event);
     void smartUpdateRouteTrackMappings(TalentRouteSnapshot route, List<Map<UUID, Integer>> growthTrackMappings);
+    TalentRouteSnapshot assignTracksToRoute(TalentRouteEvent event);
 
 
     PaginatedResponseDto<TalentRouteResponseDto> findAllBasic(Pageable pageable);

--- a/src/main/java/com/capstone/service/impl/GrowthTrackSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/GrowthTrackSnapshotServiceImpl.java
@@ -38,7 +38,10 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
     private final SkillCapsuleSnapshotService skillCapsuleSnapshotService;
 
     @Override
-    @CacheEvict(value = {"growth-tracks", "growth-tracks-with-capsules", "growth-tracks-search", "growth-track-single"}, allEntries = true)
+    @CacheEvict(value = {
+            "growth-tracks", "growth-tracks-with-capsules", "growth-tracks-search", "growth-track-single",
+            "skill-capsules-with-atoms", "skill-capsule-single",  "talent-routes-with-tracks", "talent-route-single"
+    }, allEntries = true)
     public GrowthTrackSnapshot processGrowthTrackEvent(GrowthTrackEvent event) {
         log.info("Processing growth track event for trackId: {}", event.getId());
 
@@ -220,26 +223,54 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
         }
     }
 
+    @Override
+    @CacheEvict(value = {"growth-tracks", "growth-tracks-with-capsules", "growth-tracks-search", "growth-track-single"}, allEntries = true)
+    public GrowthTrackSnapshot assignCapsulesToTrack(GrowthTrackEvent event) {
+        log.info("Assigning capsules to growth track for trackId: {}", event.getId());
+
+        try {
+            // Find existing growth track WITH capsule mappings - prevents lazy initialization error
+            Optional<GrowthTrackSnapshot> existingTrack = growthTrackSnapshotRepository.findByGrowthTrackIdWithCapsuleMappings(event.getId());
+
+            if (existingTrack.isEmpty()) {
+                throw new GrowthTrackNotFoundException(event.getId());
+            }
+
+            GrowthTrackSnapshot track = existingTrack.get();
+            log.info("Found existing growth track for assignment: {} with {} existing capsule mappings",
+                    track.getGrowthTrackId(), track.getTrackCapsuleMappings().size());
+
+            // Use existing smart update logic to assign capsules
+            if (event.getSkillCapsules() != null && !event.getSkillCapsules().isEmpty()) {
+                smartUpdateTrackCapsuleMappings(track, event.getSkillCapsules());
+
+                // Save the updated track
+                GrowthTrackSnapshot updatedTrack = growthTrackSnapshotRepository.save(track);
+
+                log.info("Successfully assigned {} capsules to growth track {}, total mappings now: {}",
+                        event.getSkillCapsules().size(), updatedTrack.getGrowthTrackId(),
+                        updatedTrack.getTrackCapsuleMappings().size());
+
+                return updatedTrack;
+            } else {
+                throw new TrackCapsuleMappingException("No skill capsule mappings provided for assignment");
+            }
+
+        } catch (GrowthTrackNotFoundException e) {
+            log.error("Growth track not found for assignment with ID: {}", event.getId(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Unexpected error assigning capsules to growth track with ID: {}", event.getId(), e);
+            throw new GrowthTrackProcessingException("Failed to assign capsules to growth track", e);
+        }
+    }
+
 
     @Override
     @Transactional(readOnly = true)
     public Optional<GrowthTrackSnapshot> findByGrowthTrackId(UUID growthTrackId) {
         log.debug("Finding track by growthTrackId: {}", growthTrackId);
         return growthTrackSnapshotRepository.findByGrowthTrackId(growthTrackId);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public boolean existsByGrowthTrackId(UUID growthTrackId) {
-        log.debug("Checking if track exists by growthTrackId: {}", growthTrackId);
-        return growthTrackSnapshotRepository.existsByGrowthTrackId(growthTrackId);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<GrowthTrackSnapshot> findByGrowthTrackIdWithCapsuleMappings(UUID growthTrackId) {
-        log.debug("Finding track with capsule mappings by growthTrackId: {}", growthTrackId);
-        return growthTrackSnapshotRepository.findByGrowthTrackIdWithCapsuleMappings(growthTrackId);
     }
 
     @Override

--- a/src/main/java/com/capstone/service/impl/SkillAtomSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/SkillAtomSnapshotServiceImpl.java
@@ -34,12 +34,15 @@ public class SkillAtomSnapshotServiceImpl implements SkillAtomSnapshotService {
     private final SkillAtomMapper skillAtomMapper;
 
     @Override
-    @CacheEvict(value = {"skill-atoms", "skill-atoms-search", "skill-atom-single"}, allEntries = true)
+    @CacheEvict(value = {
+            "skill-atoms", "skill-atoms-search", "skill-atom-single",
+            "skill-capsules-with-atoms", "skill-capsule-single"
+    }, allEntries = true)
     public SkillAtomSnapshot processSkillAtomEvent(SkillAtomEvent event) {
         log.info("Processing skill atom event for skillAtomId: {}", event.getId());
 
         try {
-            Optional<SkillAtomSnapshot> existingSkillAtom = findBySkillAtomId(event.getId());
+            Optional<SkillAtomSnapshot> existingSkillAtom = skillAtomSnapshotRepository.findBySkillAtomId(event.getId());
 
             if (existingSkillAtom.isPresent()) {
                 log.info("Skill atom exists, updating skill atom with ID: {}", event.getId());

--- a/src/main/java/com/capstone/service/impl/SkillCapsuleSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/SkillCapsuleSnapshotServiceImpl.java
@@ -38,7 +38,9 @@ public class SkillCapsuleSnapshotServiceImpl implements SkillCapsuleSnapshotServ
     private final SkillAtomSnapshotService skillAtomSnapshotService;
 
     @Override
-    @CacheEvict(value = {"skill-capsules", "skill-capsules-with-atoms", "skill-capsules-search", "skill-capsule-single"}, allEntries = true)
+    @CacheEvict(value = {"skill-capsules", "skill-capsules-with-atoms", "skill-capsules-search",
+            "skill-capsule-single", "growth-tracks-with-capsules", "growth-track-single"
+    }, allEntries = true)
     public SkillCapsuleSnapshot processSkillCapsuleEvent(SkillCapsuleEvent event) {
         log.info("Processing skill capsule event for capsuleId: {}", event.getId());
 
@@ -144,6 +146,48 @@ public class SkillCapsuleSnapshotServiceImpl implements SkillCapsuleSnapshotServ
         }
     }
 
+    @Override
+    @CacheEvict(value = {"skill-capsules", "skill-capsules-with-atoms", "skill-capsules-search", "skill-capsule-single"}, allEntries = true)
+    public SkillCapsuleSnapshot assignAtomsToCapsule(SkillCapsuleEvent event) {
+        log.info("Assigning atoms to capsule for capsuleId: {}", event.getId());
+
+        try {
+            // Find existing capsule WITH atom mappings - prevents lazy initialization error
+            Optional<SkillCapsuleSnapshot> existingCapsule = skillCapsuleSnapshotRepository.findBySkillCapsuleIdWithAtomMappings(event.getId());
+
+            if (existingCapsule.isEmpty()) {
+                throw new SkillCapsuleNotFoundException(event.getId());
+            }
+
+            SkillCapsuleSnapshot capsule = existingCapsule.get();
+            log.info("Found existing capsule for assignment: {} with {} existing atom mappings",
+                    capsule.getSkillCapsuleId(), capsule.getCapsuleAtomMappings().size());
+
+            // Use existing smart update logic to assign atoms
+            if (event.getSkillAtom() != null && !event.getSkillAtom().isEmpty()) {
+                smartUpdateCapsuleAtomMappings(capsule, event.getSkillAtom());
+
+                // Save the updated capsule
+                SkillCapsuleSnapshot updatedCapsule = skillCapsuleSnapshotRepository.save(capsule);
+
+                log.info("Successfully assigned {} atoms to capsule {}, total mappings now: {}",
+                        event.getSkillAtom().size(), updatedCapsule.getSkillCapsuleId(),
+                        updatedCapsule.getCapsuleAtomMappings().size());
+
+                return updatedCapsule;
+            } else {
+                throw new CapsuleAtomMappingException("No skill atom mappings provided for assignment");
+            }
+
+        } catch (SkillCapsuleNotFoundException e) {
+            log.error("Capsule not found for assignment with ID: {}", event.getId(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Unexpected error assigning atoms to capsule with ID: {}", event.getId(), e);
+            throw new SkillCapsuleProcessingException("Failed to assign atoms to capsule", e);
+        }
+    }
+
     /**
      * Verify all atoms exist and parse into structured format
      */
@@ -234,20 +278,6 @@ public class SkillCapsuleSnapshotServiceImpl implements SkillCapsuleSnapshotServ
     public Optional<SkillCapsuleSnapshot> findBySkillCapsuleId(UUID skillCapsuleId) {
         log.debug("Finding capsule by skillCapsuleId: {}", skillCapsuleId);
         return skillCapsuleSnapshotRepository.findBySkillCapsuleId(skillCapsuleId);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public boolean existsBySkillCapsuleId(UUID skillCapsuleId) {
-        log.debug("Checking if capsule exists by skillCapsuleId: {}", skillCapsuleId);
-        return skillCapsuleSnapshotRepository.existsBySkillCapsuleId(skillCapsuleId);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Optional<SkillCapsuleSnapshot> findBySkillCapsuleIdWithAtomMappings(UUID skillCapsuleId) {
-        log.debug("Finding capsule with atom mappings by skillCapsuleId: {}", skillCapsuleId);
-        return skillCapsuleSnapshotRepository.findBySkillCapsuleIdWithAtomMappings(skillCapsuleId);
     }
 
     @Override

--- a/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
@@ -38,7 +38,10 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
     private final GrowthTrackSnapshotService growthTrackSnapshotService;
 
     @Override
-    @CacheEvict(value = {"talent-routes", "talent-routes-with-tracks", "talent-routes-search", "talent-route-single"}, allEntries = true)
+    @CacheEvict(value = {
+            "talent-routes", "talent-routes-with-tracks", "talent-routes-search", "talent-route-single",
+            "growth-tracks-with-capsules", "growth-track-single"
+    }, allEntries = true)
     public TalentRouteSnapshot processTalentRouteEvent(TalentRouteEvent event) {
         log.info("Processing talent route event for routeId: {}", event.getId());
 
@@ -217,6 +220,47 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
         // Add new mappings
         if (!analysis.getToAdd().isEmpty()) {
             route.getRouteTrackMappings().addAll(analysis.getToAdd());
+        }
+    }
+
+    @CacheEvict(value = {"talent-routes", "talent-routes-with-tracks", "talent-routes-search", "talent-route-single"}, allEntries = true)
+    public TalentRouteSnapshot assignTracksToRoute(TalentRouteEvent event) {
+        log.info("Assigning tracks to talent route for routeId: {}", event.getId());
+
+        try {
+            // Find existing talent route WITH track mappings - prevents lazy initialization error
+            Optional<TalentRouteSnapshot> existingRoute = talentRouteSnapshotRepository.findByTalentRouteIdWithTrackMappings(event.getId());
+
+            if (existingRoute.isEmpty()) {
+                throw new TalentRouteNotFoundException(event.getId());
+            }
+
+            TalentRouteSnapshot route = existingRoute.get();
+            log.info("Found existing talent route for assignment: {} with {} existing track mappings",
+                    route.getTalentRouteId(), route.getRouteTrackMappings().size());
+
+            // Use existing smart update logic to assign tracks
+            if (event.getGrowthTracks() != null && !event.getGrowthTracks().isEmpty()) {
+                smartUpdateRouteTrackMappings(route, event.getGrowthTracks());
+
+                // Save the updated route
+                TalentRouteSnapshot updatedRoute = talentRouteSnapshotRepository.save(route);
+
+                log.info("Successfully assigned {} tracks to talent route {}, total mappings now: {}",
+                        event.getGrowthTracks().size(), updatedRoute.getTalentRouteId(),
+                        updatedRoute.getRouteTrackMappings().size());
+
+                return updatedRoute;
+            } else {
+                throw new RouteTrackMappingException("No growth track mappings provided for assignment");
+            }
+
+        } catch (TalentRouteNotFoundException e) {
+            log.error("Talent route not found for assignment with ID: {}", event.getId(), e);
+            throw e;
+        } catch (Exception e) {
+            log.error("Unexpected error assigning tracks to talent route with ID: {}", event.getId(), e);
+            throw new TalentRouteProcessingException("Failed to assign tracks to talent route", e);
         }
     }
 


### PR DESCRIPTION
# 🚀   Pull Request: Additional Integration of Kafka Events into the Roadmap Service
### 🎫   Jira Ticket
[:link:  SPRINT-2/VER-20: Consuming Kafka  update events and persist them into the database](https://amali-tech.atlassian.net/browse/VER-152)
---
### ✅   Summary
This PR provides the integration for kafka update events such as   `talentRoute.update`, `talentRoute.assign`, `growthTrack.update`, `growthTrack.assign`, `capsule.update`, `capsule.assign` and `atom.update`  in Roadmap service to consume the event and persist the information into the database.
---
### :pushpin:  Features  Added
- [x] Added update and assign event listeners for both Capsules and Growth Tracks
- [x] Implemented smart assignment logic that only updates mappings without touching metadata
- [x] Added comprehensive error handling with operation type differentiation for DLT debugging
- [x] Identified and fixed cache isolation bug 
