### PR TITLE
Restrict learner to follow one talent route at a time

### DIFF
--- a/src/main/java/com/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/config/SecurityConfig.java
@@ -49,8 +49,8 @@ public class SecurityConfig {
 
                 // Mixed access endpoints (roadmap operations)
                 .requestMatchers("/api/v1/roadmap").hasAnyRole("ADMIN", "LEARNER")
-                .requestMatchers("/api/v1/roadmap/start-progress").hasRole("LEARNER")
-                .requestMatchers("/api/v1/roadmap/complete-atom-progress").hasRole("LEARNER")
+                .requestMatchers("/api/v1/roadmap/start-progress").hasRole("ADMIN")
+                .requestMatchers("/api/v1/roadmap/complete-atom-progress").hasRole("ADMIN")
                 .requestMatchers("/api/v1/roadmap/recalculate-progress").hasAnyRole("ADMIN", "LEARNER")
 
                 // Learner-only endpoints (learner view)

--- a/src/main/java/com/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/config/SecurityConfig.java
@@ -49,8 +49,8 @@ public class SecurityConfig {
 
                 // Mixed access endpoints (roadmap operations)
                 .requestMatchers("/api/v1/roadmap").hasAnyRole("ADMIN", "LEARNER")
-                .requestMatchers("/api/v1/roadmap/start-progress").hasRole("ADMIN")
-                .requestMatchers("/api/v1/roadmap/complete-atom-progress").hasRole("ADMIN")
+                .requestMatchers("/api/v1/roadmap/start-progress").hasRole("LEARNER")
+                .requestMatchers("/api/v1/roadmap/complete-atom-progress").hasRole("LEARNER")
                 .requestMatchers("/api/v1/roadmap/recalculate-progress").hasAnyRole("ADMIN", "LEARNER")
 
                 // Learner-only endpoints (learner view)

--- a/src/main/java/com/capstone/model/LearnerCapsuleProgress.java
+++ b/src/main/java/com/capstone/model/LearnerCapsuleProgress.java
@@ -48,7 +48,7 @@ public class LearnerCapsuleProgress {
     @Min(value = 0, message = "Progress percentage cannot be negative")
     @Max(value = 100, message = "Progress percentage cannot exceed 100")
     @Column(name = "progress_percentage")
-    private Integer progressPercentage = 0;
+    private Double progressPercentage = 0.0;
 
     @Column(name = "started_at")
     private LocalDateTime startedAt;

--- a/src/main/java/com/capstone/model/LearnerRoadmap.java
+++ b/src/main/java/com/capstone/model/LearnerRoadmap.java
@@ -49,7 +49,7 @@ public class LearnerRoadmap {
     @Min(value = 0, message = "Progress percentage cannot be negative")
     @Max(value = 100, message = "Progress percentage cannot exceed 100")
     @Column(name = "overall_progress_percentage")
-    private Integer overallProgressPercentage = 0;
+    private Double overallProgressPercentage = 0.0;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/capstone/model/LearnerTrackProgress.java
+++ b/src/main/java/com/capstone/model/LearnerTrackProgress.java
@@ -49,7 +49,7 @@ public class LearnerTrackProgress {
     @Min(value = 0, message = "Progress percentage cannot be negative")
     @Max(value = 100, message = "Progress percentage cannot exceed 100")
     @Column(name = "progress_percentage")
-    private Integer progressPercentage = 0;
+    private Double progressPercentage = 0.0;
 
     @Column(name = "started_at")
     private LocalDateTime startedAt;

--- a/src/main/java/com/capstone/repository/LearnerRoadmapRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerRoadmapRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -27,5 +28,14 @@ public interface LearnerRoadmapRepository extends JpaRepository<LearnerRoadmap, 
         AND rm.enrollmentStatus = 'ACTIVE'
     """)
     Optional<LearnerRoadmap> findActiveRoadmapByUserId(@Param("learnerId") UUID learnerId);
+
+    @Query("""
+        SELECT rm FROM LearnerRoadmap rm
+        WHERE rm.userId = :userId
+        AND rm.talentRoute.talentRouteId != :talentRouteId
+    """)
+    List<LearnerRoadmap> findLearnerRoadmapByUserIdANDTalentRouteId(@Param("userId") UUID userId,
+                                                                    @Param("talentRouteId") UUID talentRouteId);
+
 
 }

--- a/src/main/java/com/capstone/repository/LearnerTrackProgressRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerTrackProgressRepository.java
@@ -1,5 +1,6 @@
 package com.capstone.repository;
 
+import com.capstone.model.LearnerRoadmap;
 import com.capstone.model.LearnerTrackProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -37,4 +38,13 @@ public interface LearnerTrackProgressRepository extends JpaRepository<LearnerTra
         ORDER BY rtm.sequenceOrder
     """)
     List<Object[]> findTrackProgressesByLearnerIdWithSequence(@Param("learnerId") UUID learnerId);
+
+    @Query("""
+        SELECT tp FROM LearnerTrackProgress tp
+        WHERE tp.learnerRoadmap.userId = :userId
+        AND tp.growthTrack.growthTrackId != :trackId
+    """)
+    List<LearnerTrackProgress> findTrackProgressByUserIdAndTrackId(@Param("userId") UUID userId,
+                                                                   @Param("trackId") UUID trackId);
+
 }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -2,10 +2,7 @@ package com.capstone.service.impl;
 
 import com.capstone.dto.roadmap.AtomProgressRequestDto;
 import com.capstone.dto.roadmap.RecalculateProgressRequestDto;
-import com.capstone.exception.LessonException;
-import com.capstone.exception.ProgressExistException;
-import com.capstone.exception.ProgressNotFoundException;
-import com.capstone.exception.TalentRouteNotFoundException;
+import com.capstone.exception.*;
 import com.capstone.model.*;
 import com.capstone.repository.*;
 import com.capstone.service.LearnerProgressService;
@@ -27,6 +24,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
     private final RouteTrackMappingRepository routeTrackMappingRepository;
     private final GrowthTrackCapsuleMappingRepository growthTrackCapsuleMappingRepository;
     private final CapsuleAtomMappingRepository capsuleAtomMappingRepository;
+    private final LearnerTrackProgressRepository learnerTrackProgressRepository;
 
     @Transactional
     @Override
@@ -38,7 +36,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
 
         startAtomProgress(atomProgress); // start atom progress
         LearnerCapsuleProgress capsuleProgress = getCapsuleProgress(atomProgress); // start capsule progress
-        startGrowthTrackProgress(capsuleProgress); // start growth track progress
+        startGrowthTrackProgress(atomProgressRequestDto.getLearnerId(), capsuleProgress); // start growth track progress
 
         learnerAtomProgressRepository.save(atomProgress);
 
@@ -64,8 +62,20 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         return capsuleProgress;
     }
 
-    private void startGrowthTrackProgress(LearnerCapsuleProgress capsuleProgress){
+    private void startGrowthTrackProgress(UUID learnerId, LearnerCapsuleProgress capsuleProgress){
         LearnerTrackProgress trackProgress = capsuleProgress.getLearnerTrackProgress();
+        List<LearnerTrackProgress> learnerTrackProgressList = learnerTrackProgressRepository
+                .findTrackProgressByUserIdAndTrackId(learnerId, trackProgress.getGrowthTrack().getGrowthTrackId());
+        //find an ongoing learner growth track
+        if(!learnerTrackProgressList.isEmpty()){
+            long uncompletedGrowthTrackNumber = learnerTrackProgressList.stream()
+                    .filter(track->track.getStatus().equals(ProgressStatus.IN_PROGRESS))
+                    .count();
+            if(uncompletedGrowthTrackNumber >=1 ){
+                throw new RoadmapExistException("You have an ongoing growth track, you cannot start a new one!");
+            }
+        }
+
         if(trackProgress.getStatus().equals(ProgressStatus.NOT_STARTED)){
             trackProgress.setStartedAt(LocalDateTime.now());
             trackProgress.setStartedAt(LocalDateTime.now());

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -153,13 +153,18 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         LearnerRoadmap learnerRoadmap = growthTrackProgress.getLearnerRoadmap();
         List<LearnerTrackProgress> growthTrackProgressList = learnerRoadmap.getLearnerTrackProgresses();
 
+        // only calculate the overall talent route percentage for growth tracks that are unlocked
+        List<LearnerTrackProgress> growthTracksTakenByLearner = growthTrackProgressList.stream()
+                .filter(track-> !track.getStatus().equals(ProgressStatus.NOT_STARTED))
+                .toList();
+
         // get the sum of growth track percentages
-        double sumOfGrowthTracksPercentage = growthTrackProgressList.stream()
+        double sumOfGrowthTracksPercentage = growthTracksTakenByLearner.stream()
                 .map(LearnerTrackProgress::getProgressPercentage)
                 .reduce(0.0, Double::sum);
 
         // calculate percentage
-        double learnerRoadmapPercentage = growthTrackProgressList.isEmpty() ? 0.0 : sumOfGrowthTracksPercentage/growthTrackProgressList.size();
+        double learnerRoadmapPercentage = growthTrackProgressList.isEmpty() ? 0.0 : sumOfGrowthTracksPercentage/growthTracksTakenByLearner.size();
         double roundedPercentage = Math.ceil(learnerRoadmapPercentage * 10.0) / 10.0;
 
         if(roundedPercentage >= 100.0){
@@ -291,7 +296,12 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
     private void recalculateTalentRoutePercentage(LearnerRoadmap talentRoute,
                                                   List<LearnerTrackProgress> growthTracks,
                                                   double totalGrowthTrackPercentage ){
-        double talentRoutePercentage = growthTracks.isEmpty() ? 0.0 : totalGrowthTrackPercentage / growthTracks.size();
+
+        // only calculate the overall talent route percentage for growth tracks that are unlocked
+        List<LearnerTrackProgress> growthTracksTakenByLearner = growthTracks.stream()
+                .filter(track-> !track.getStatus().equals(ProgressStatus.NOT_STARTED))
+                .toList();
+        double talentRoutePercentage = growthTracksTakenByLearner.isEmpty() ? 0.0 : totalGrowthTrackPercentage / growthTracksTakenByLearner.size();
         double roundedPercentage = Math.ceil(talentRoutePercentage * 10.0) / 10.0;
         talentRoute.setOverallProgressPercentage(roundedPercentage);
 

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -113,13 +113,15 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                 .count();
 
         // calculate percentage
-        int capsulePercentage =  atomProgressList.isEmpty() ? 0 : (int)(completedAtomsNumber * 100)/atomProgressList.size();
+        double capsulePercentage =  atomProgressList.isEmpty() ? 0.0 : (completedAtomsNumber * 100.0)/atomProgressList.size();
+        double roundedPercentage = Math.ceil(capsulePercentage * 10.0) / 10.0;
 
-        if(capsulePercentage == 100){
+        if(roundedPercentage >= 100.0){
             capsuleProgress.setStatus(ProgressStatus.COMPLETED);
             capsuleProgress.setCompletedAt(LocalDateTime.now());
+            roundedPercentage = 100.0;
         }
-        capsuleProgress.setProgressPercentage(capsulePercentage);
+        capsuleProgress.setProgressPercentage(roundedPercentage);
 
         return capsuleProgress;
     }
@@ -129,18 +131,20 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         List<LearnerCapsuleProgress> capsuleProgressList = growthTrackProgress.getLearnerCapsuleProgresses();
 
         // get the sum of capsule percentages
-        long sumOfCapsulesPercentage = capsuleProgressList.stream()
+        double sumOfCapsulesPercentage = capsuleProgressList.stream()
                 .map(LearnerCapsuleProgress::getProgressPercentage)
-                .reduce(0, Integer::sum);
+                .reduce(0.0, Double::sum);
 
         // calculate percentage
-        int trackPercentage = capsuleProgressList.isEmpty() ? 0 : (int)(sumOfCapsulesPercentage/capsuleProgressList.size());
+        double trackPercentage = capsuleProgressList.isEmpty() ? 0.0 : sumOfCapsulesPercentage/capsuleProgressList.size();
+        double roundedPercentage = Math.ceil(trackPercentage * 10.0) / 10.0;
 
-        if(trackPercentage == 100){
+        if(roundedPercentage >= 100.0){
             growthTrackProgress.setStatus(ProgressStatus.COMPLETED);
             growthTrackProgress.setCompletedAt(LocalDateTime.now());
+            roundedPercentage = 100.0;
         }
-        growthTrackProgress.setProgressPercentage(trackPercentage);
+        growthTrackProgress.setProgressPercentage(roundedPercentage);
 
         return growthTrackProgress;
     }
@@ -150,18 +154,20 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         List<LearnerTrackProgress> growthTrackProgressList = learnerRoadmap.getLearnerTrackProgresses();
 
         // get the sum of growth track percentages
-        long sumOfGrowthTracksPercentage = growthTrackProgressList.stream()
+        double sumOfGrowthTracksPercentage = growthTrackProgressList.stream()
                 .map(LearnerTrackProgress::getProgressPercentage)
-                .reduce(0, Integer::sum);
+                .reduce(0.0, Double::sum);
 
         // calculate percentage
-        int learnerRoadmapPercentage = growthTrackProgressList.isEmpty() ? 0 : (int)(sumOfGrowthTracksPercentage/growthTrackProgressList.size());
+        double learnerRoadmapPercentage = growthTrackProgressList.isEmpty() ? 0.0 : sumOfGrowthTracksPercentage/growthTrackProgressList.size();
+        double roundedPercentage = Math.ceil(learnerRoadmapPercentage * 10.0) / 10.0;
 
-        if(learnerRoadmapPercentage == 100){
+        if(roundedPercentage >= 100.0){
             learnerRoadmap.setCompletionDate(LocalDateTime.now());
+            roundedPercentage = 100.0;
         }
 
-        learnerRoadmap.setOverallProgressPercentage(learnerRoadmapPercentage);
+        learnerRoadmap.setOverallProgressPercentage(roundedPercentage);
 
         return learnerRoadmap;
     }
@@ -196,7 +202,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                         .learnerRoadmap(talentRoute)
                         .growthTrack(growthTrack)
                         .status(ProgressStatus.NOT_STARTED)
-                        .progressPercentage(0)
+                        .progressPercentage(0.0)
                         .build();
 
                 talentRoute.getLearnerTrackProgresses().add(learnerGrowthTrackProgress); // add growth track to roadmap
@@ -227,7 +233,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                         .learnerTrackProgress(learnerGrowthTrackProgress)
                         .skillCapsule(capsule)
                         .status(ProgressStatus.NOT_STARTED)
-                        .progressPercentage(0)
+                        .progressPercentage(0.0)
                         .build();
 
                 // attach the learner capsule progress to growth track progress
@@ -275,7 +281,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
     public void recalculateProgress(LearnerRoadmap talentRoute) {
         // Recalculate all growth tracks progresses
         List<LearnerTrackProgress> growthTracks = talentRoute.getLearnerTrackProgresses();
-        int totalGrowthTrackPercentage = getTotalGrowthTrackPercentageInTalentRoute(growthTracks);
+        double totalGrowthTrackPercentage = getTotalGrowthTrackPercentageInTalentRoute(growthTracks);
 
         // Recalculate talentRoute percentage
         recalculateTalentRoutePercentage(talentRoute, growthTracks, totalGrowthTrackPercentage);
@@ -284,46 +290,50 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
 
     private void recalculateTalentRoutePercentage(LearnerRoadmap talentRoute,
                                                   List<LearnerTrackProgress> growthTracks,
-                                                  int totalGrowthTrackPercentage ){
-        int talentRoutePercentage = growthTracks.isEmpty() ? 0 : totalGrowthTrackPercentage / growthTracks.size();
-        talentRoute.setOverallProgressPercentage(talentRoutePercentage);
+                                                  double totalGrowthTrackPercentage ){
+        double talentRoutePercentage = growthTracks.isEmpty() ? 0.0 : totalGrowthTrackPercentage / growthTracks.size();
+        double roundedPercentage = Math.ceil(talentRoutePercentage * 10.0) / 10.0;
+        talentRoute.setOverallProgressPercentage(roundedPercentage);
 
-        if (talentRoutePercentage == 0) {
+        if (roundedPercentage == 0.0) {
             talentRoute.setEnrollmentStatus(EnrollmentStatus.ACTIVE); // still enrolled, not started
-        } else if (talentRoutePercentage == 100) {
+        } else if (roundedPercentage >= 100.0) {
             talentRoute.setEnrollmentStatus(EnrollmentStatus.COMPLETED);
         }
 
         learnerRoadmapRepository.save(talentRoute); // store roadmap updated progress in the Database
     }
 
-    private int getTotalGrowthTrackPercentageInTalentRoute(List<LearnerTrackProgress> growthTracks){
-        int totalTrackPercentage = 0; // this is required to update roadmap overall percentage
+    private double getTotalGrowthTrackPercentageInTalentRoute(List<LearnerTrackProgress> growthTracks){
+        double totalTrackPercentage = 0.0; // this is required to update roadmap overall percentage
 
         // loop throw each growth track progress to recalculate percentage and the get the new percentage
         for (LearnerTrackProgress growthTrackProgress : growthTracks) {
             // first get the total percentage of capsule to calculate the growth track percentage
             List<LearnerCapsuleProgress> capsules = growthTrackProgress.getLearnerCapsuleProgresses();
-            int totalCapsulePercentage = getTotalCapsulePercentageInGrowthTrack(capsules);
+            double totalCapsulePercentage = getTotalCapsulePercentageInGrowthTrack(capsules);
 
             // update current growth track progress information
-            int currentGrowthTrackPercentage = capsules.isEmpty() ? 0 : totalCapsulePercentage / capsules.size();
-            growthTrackProgress.setProgressPercentage(currentGrowthTrackPercentage);
+            double currentGrowthTrackPercentage = capsules.isEmpty() ? 0.0 : totalCapsulePercentage / capsules.size();
+            double roundedPercentage = Math.ceil(currentGrowthTrackPercentage * 10.0) / 10.0;
+            growthTrackProgress.setProgressPercentage(roundedPercentage);
 
             // set growth track status
-            switch (currentGrowthTrackPercentage) {
-                case 0 -> growthTrackProgress.setStatus(ProgressStatus.NOT_STARTED);
-                case 100 -> growthTrackProgress.setStatus(ProgressStatus.COMPLETED);
-                default -> growthTrackProgress.setStatus(ProgressStatus.IN_PROGRESS);
+            if(roundedPercentage == 0.0){
+                growthTrackProgress.setStatus(ProgressStatus.NOT_STARTED);
+            } else if (roundedPercentage >= 100.0) {
+                growthTrackProgress.setStatus(ProgressStatus.COMPLETED);
+            }else{
+                growthTrackProgress.setStatus(ProgressStatus.IN_PROGRESS);
             }
 
-            totalTrackPercentage += currentGrowthTrackPercentage;
+            totalTrackPercentage += roundedPercentage;
         }
         return totalTrackPercentage;
     }
 
-    private int getTotalCapsulePercentageInGrowthTrack(List<LearnerCapsuleProgress> capsules){
-        int totalCapsulePercentage = 0; // this is required to calculate the growth track percentage
+    private double getTotalCapsulePercentageInGrowthTrack(List<LearnerCapsuleProgress> capsules){
+        double totalCapsulePercentage = 0.0; // this is required to calculate the growth track percentage
 
         // loop throw each capsule progress to recalculate percentage and the get the new percentage
         for (LearnerCapsuleProgress capsuleProgress : capsules) {
@@ -334,19 +344,18 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                     .filter(LearnerAtomProgress::isCompleted)
                     .count();
 
-            int currentCapsulePercentage = atoms.isEmpty() ? 0 :
-                    (completedAtoms * 100) / atoms.size();
+            double currentCapsulePercentage = atoms.isEmpty() ? 0.0 :
+                    (completedAtoms * 100.0) / atoms.size();
 
             capsuleProgress.setProgressPercentage(currentCapsulePercentage);
 
             // update current capsule progress information
-            switch (currentCapsulePercentage) {
-                case 0 ->
-                        capsuleProgress.setStatus(ProgressStatus.NOT_STARTED);
-                case 100 ->
-                        capsuleProgress.setStatus(ProgressStatus.COMPLETED);
-                default ->
-                        capsuleProgress.setStatus(ProgressStatus.IN_PROGRESS);
+            if(currentCapsulePercentage == 0.0){
+                capsuleProgress.setStatus(ProgressStatus.NOT_STARTED);
+            } else if (currentCapsulePercentage >= 100.0) {
+                capsuleProgress.setStatus(ProgressStatus.COMPLETED);
+            }else{
+                capsuleProgress.setStatus(ProgressStatus.IN_PROGRESS);
             }
 
             totalCapsulePercentage += currentCapsulePercentage;

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -319,7 +319,9 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
             talentRoute.setEnrollmentStatus(EnrollmentStatus.ACTIVE); // still enrolled, not started
         } else if (roundedPercentage >= 100.0) {
             talentRoute.setEnrollmentStatus(EnrollmentStatus.COMPLETED);
+            roundedPercentage = 100.0;
         }
+        talentRoute.setOverallProgressPercentage(roundedPercentage);
 
         learnerRoadmapRepository.save(talentRoute); // store roadmap updated progress in the Database
     }
@@ -343,6 +345,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                 growthTrackProgress.setStatus(ProgressStatus.NOT_STARTED);
             } else if (roundedPercentage >= 100.0) {
                 growthTrackProgress.setStatus(ProgressStatus.COMPLETED);
+                roundedPercentage = 100.0;
             }else{
                 growthTrackProgress.setStatus(ProgressStatus.IN_PROGRESS);
             }
@@ -374,6 +377,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
                 capsuleProgress.setStatus(ProgressStatus.NOT_STARTED);
             } else if (currentCapsulePercentage >= 100.0) {
                 capsuleProgress.setStatus(ProgressStatus.COMPLETED);
+                currentCapsulePercentage = 100.0;
             }else{
                 capsuleProgress.setStatus(ProgressStatus.IN_PROGRESS);
             }

--- a/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerProgressServiceImpl.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -116,7 +115,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         // calculate percentage
         int capsulePercentage =  atomProgressList.isEmpty() ? 0 : (int)(completedAtomsNumber * 100)/atomProgressList.size();
 
-        if(capsuleProgress.getProgressPercentage() == 100){
+        if(capsulePercentage == 100){
             capsuleProgress.setStatus(ProgressStatus.COMPLETED);
             capsuleProgress.setCompletedAt(LocalDateTime.now());
         }
@@ -137,7 +136,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         // calculate percentage
         int trackPercentage = capsuleProgressList.isEmpty() ? 0 : (int)(sumOfCapsulesPercentage/capsuleProgressList.size());
 
-        if(growthTrackProgress.getProgressPercentage() == 100){
+        if(trackPercentage == 100){
             growthTrackProgress.setStatus(ProgressStatus.COMPLETED);
             growthTrackProgress.setCompletedAt(LocalDateTime.now());
         }
@@ -158,7 +157,7 @@ public class LearnerProgressServiceImpl implements LearnerProgressService {
         // calculate percentage
         int learnerRoadmapPercentage = growthTrackProgressList.isEmpty() ? 0 : (int)(sumOfGrowthTracksPercentage/growthTrackProgressList.size());
 
-        if(learnerRoadmap.getOverallProgressPercentage() == 100){
+        if(learnerRoadmapPercentage == 100){
             learnerRoadmap.setCompletionDate(LocalDateTime.now());
         }
 

--- a/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
@@ -89,6 +89,7 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
         }
 
         List<LearnerRoadmap> learnerRoadmapList = learnerRoadmapRepository.findLearnerRoadmapByUserIdANDTalentRouteId(learnerId, talentRouteId);
+        // find an ongoing learner roadmap
         if(!learnerRoadmapList.isEmpty()){
             long uncompletedRoadmapNumber = learnerRoadmapList.stream()
                     .filter(roadmap->roadmap.getOverallProgressPercentage() < 100.0)

--- a/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
@@ -88,6 +88,16 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
             throw new RoadmapExistException("You are already enrolled in this roadmap");
         }
 
+        List<LearnerRoadmap> learnerRoadmapList = learnerRoadmapRepository.findLearnerRoadmapByUserIdANDTalentRouteId(learnerId, talentRouteId);
+        if(!learnerRoadmapList.isEmpty()){
+            long uncompletedRoadmapNumber = learnerRoadmapList.stream()
+                    .filter(roadmap->roadmap.getOverallProgressPercentage() < 100.0)
+                    .count();
+            if(uncompletedRoadmapNumber >= 1){
+                throw new RoadmapExistException("You have an ongoing roadmap, you cannot start a new one!");
+            }
+        }
+
         return LearnerRoadmap.builder()
                 .talentRoute(talentRoute)
                 .userId(learnerId)

--- a/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/LearnerRoadmapServiceImpl.java
@@ -14,7 +14,6 @@ import com.capstone.service.LearnerRoadmapService;
 import lombok.extern.slf4j.Slf4j;
 import org.common.event.LearnerOnBoardingEvent;
 import lombok.RequiredArgsConstructor;
-import org.common.event.ProduceUserEvent;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -93,7 +92,7 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
                 .talentRoute(talentRoute)
                 .userId(learnerId)
                 .enrollmentStatus(EnrollmentStatus.ACTIVE)
-                .overallProgressPercentage(0)
+                .overallProgressPercentage(0.0)
                 .build();
     }
 
@@ -104,7 +103,7 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
                             .learnerRoadmap(learnerRoadmap)
                             .growthTrack(track)
                             .status(ProgressStatus.NOT_STARTED)
-                            .progressPercentage(0)
+                            .progressPercentage(0.0)
                             .build();
 
                     // create immediately capsule progress for this growth track
@@ -133,7 +132,7 @@ public class LearnerRoadmapServiceImpl implements LearnerRoadmapService {
                         .learnerTrackProgress(learnerTrackProgress)
                         .skillCapsule(capsule)
                         .status(ProgressStatus.NOT_STARTED)
-                        .progressPercentage(0)
+                        .progressPercentage(0.0)
                         .build();
 
                     // create atom progress immediately for this capsule


### PR DESCRIPTION
# 🚀 PR: Restrict learner to follow one talent route at a time

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-20: Implement Learner Progress Tracking from Skill Atom to Talent route.](https://amali-tech.atlassian.net/browse/VER-118)

---

## ✅ Summary

These changes restrict a learner to one talent route or growth track until the current one is completed.

---

## 📌 Feature

- [x] Restrict the learner to select one talent route
- [x] Restrict the learner to select one growth track
- [x] Refactor progress percentage data type 

---

## 🚧 Next Task

- Fetch learners who are assinged to a specific mentor.