### PR TITLE
Feat: GrowthTrack and TalentRoute Image Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.6.0</version>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.20.26</version>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.common</groupId>
             <artifactId>versapath-events</artifactId>
-            <version>3.1.1</version>
+            <version>3.1.2</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/config/S3BucketConfig.java
+++ b/src/main/java/com/capstone/config/S3BucketConfig.java
@@ -1,0 +1,42 @@
+package com.capstone.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import org.springframework.beans.factory.annotation.Value;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3BucketConfig {
+    @Value("${AWS_ACCESS_KEY_ID}")
+    private String accessKey;
+
+    @Value("${AWS_SECRET_ACCESS_KEY}")
+    private String secretKey;
+
+    @Value("${AWS_REGION}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+                )
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/capstone/controller/RoadmapController.java
+++ b/src/main/java/com/capstone/controller/RoadmapController.java
@@ -2,11 +2,14 @@ package com.capstone.controller;
 
 import com.capstone.dto.response.ApiResponseDto;
 import com.capstone.dto.request.RecalculateProgressRequestDto;
+import com.capstone.dto.request.RoadmapRequestDto;
 import com.capstone.dto.request.AtomProgressRequestDto;
 import com.capstone.service.LearnerProgressService;
+import com.capstone.service.LearnerRoadmapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,7 +18,14 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/roadmap")
 @Tag(name = "Roadmap Controller", description = "Manage all roadmap's api")
 public class RoadmapController {
+    private final LearnerRoadmapService learnerRoadmapService;
     private final LearnerProgressService learnerProgressService;
+    @PostMapping()
+    @Operation(summary = "Assign track", description = "This end point allows a learner to select talent route")
+    public ResponseEntity<ApiResponseDto<String>> assignRouteToLearner(@RequestBody RoadmapRequestDto roadmapRequestDto) {
+        learnerRoadmapService.assignLearnerToTalentRoute(roadmapRequestDto);
+        return ResponseEntity.ok(ApiResponseDto.success("You've successfully enrolled in a talent route"));
+    }
 
     @PostMapping("/start-progress")
     @Operation(summary = "Start progress", description = "This end point gets a learner to start tracking progress")

--- a/src/main/java/com/capstone/controller/RoadmapController.java
+++ b/src/main/java/com/capstone/controller/RoadmapController.java
@@ -9,7 +9,6 @@ import com.capstone.service.LearnerRoadmapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/capstone/dto/response/GrowthTrackResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/GrowthTrackResponseDto.java
@@ -20,6 +20,7 @@ public class GrowthTrackResponseDto {
     private UUID growthTrackId;
     private String trackName;
     private String description;
+    private String image;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Integer totalCapsules;

--- a/src/main/java/com/capstone/dto/response/GrowthTrackSummaryDto.java
+++ b/src/main/java/com/capstone/dto/response/GrowthTrackSummaryDto.java
@@ -18,6 +18,7 @@ public class GrowthTrackSummaryDto {
     private UUID growthTrackId;
     private String trackName;
     private String description;
+    private String image;
     private Integer sequenceOrder;
     private Integer totalCapsules;
 }

--- a/src/main/java/com/capstone/dto/response/TalentRouteResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/TalentRouteResponseDto.java
@@ -20,6 +20,7 @@ public class TalentRouteResponseDto {
     private UUID talentRouteId;
     private String routeName;
     private String description;
+    private String image;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Integer totalTracks;

--- a/src/main/java/com/capstone/mapper/TalentRouteMapper.java
+++ b/src/main/java/com/capstone/mapper/TalentRouteMapper.java
@@ -25,6 +25,7 @@ public interface TalentRouteMapper {
     @Mapping(source = "growthTrack.growthTrackId", target = "growthTrackId")
     @Mapping(source = "growthTrack.trackName", target = "trackName")
     @Mapping(source = "growthTrack.description", target = "description")
+    @Mapping(source = "growthTrack.image", target = "image")
     GrowthTrackSummaryDto toGrowthTrackSummaryDto(RouteTrackMapping mapping);
 
     List<GrowthTrackSummaryDto> toGrowthTrackSummaryDtoList(List<RouteTrackMapping> mappings);

--- a/src/main/java/com/capstone/model/GrowthTrackSnapshot.java
+++ b/src/main/java/com/capstone/model/GrowthTrackSnapshot.java
@@ -38,6 +38,9 @@ public class GrowthTrackSnapshot {
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
+    @Column(name = "image", columnDefinition = "TEXT")
+    private String image;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/capstone/model/TalentRouteSnapshot.java
+++ b/src/main/java/com/capstone/model/TalentRouteSnapshot.java
@@ -37,6 +37,9 @@ public class TalentRouteSnapshot {
     @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
+    @Column(name = "image", columnDefinition = "TEXT")
+    private String image;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/capstone/service/S3ImageService.java
+++ b/src/main/java/com/capstone/service/S3ImageService.java
@@ -1,0 +1,5 @@
+package com.capstone.service;
+
+public interface S3ImageService {
+    String generatePresignedUrl(String imageKey);
+}

--- a/src/main/java/com/capstone/service/impl/GrowthTrackSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/GrowthTrackSnapshotServiceImpl.java
@@ -10,6 +10,7 @@ import com.capstone.model.SkillCapsuleSnapshot;
 import com.capstone.model.TrackCapsuleMapping;
 import com.capstone.repository.GrowthTrackSnapshotRepository;
 import com.capstone.service.GrowthTrackSnapshotService;
+import com.capstone.service.S3ImageService;
 import com.capstone.service.SkillCapsuleSnapshotService;
 import com.capstone.util.PaginationUtil;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
     private final GrowthTrackEventMapper growthTrackEventMapper;
     private final GrowthTrackMapper growthTrackMapper;
     private final SkillCapsuleSnapshotService skillCapsuleSnapshotService;
+    private final S3ImageService s3ImageService;
 
     @Override
     @CacheEvict(value = {
@@ -277,9 +279,15 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
     @Transactional(readOnly = true)
     @Cacheable(value = "growth-tracks", key = "#pageable.pageNumber + '-' + #pageable.pageSize")
     public PaginatedResponseDto<GrowthTrackResponseDto> findAllBasic(Pageable pageable) {
-        log.debug("Finding all growth tracks with basic info, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        log.debug("Finding all growth tracks (basic) with pagination: page={}, size={}",
+                pageable.getPageNumber(), pageable.getPageSize());
+
         Page<GrowthTrackSnapshot> pageData = growthTrackSnapshotRepository.findAll(pageable);
-        Page<GrowthTrackResponseDto> dtoPage = pageData.map(growthTrackMapper::toBasicResponseDto);
+        Page<GrowthTrackResponseDto> dtoPage = pageData.map(entity -> {
+            GrowthTrackResponseDto dto = growthTrackMapper.toBasicResponseDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -287,9 +295,15 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
     @Transactional(readOnly = true)
     @Cacheable(value = "growth-tracks-with-capsules", key = "#pageable.pageNumber + '-' + #pageable.pageSize")
     public PaginatedResponseDto<GrowthTrackResponseDto> findAllWithCapsuleSummaries(Pageable pageable) {
-        log.debug("Finding all growth tracks with capsule summaries, page: {}, size: {}", pageable.getPageNumber(), pageable.getPageSize());
+        log.debug("Finding all growth tracks with capsule summaries: page={}, size={}",
+                pageable.getPageNumber(), pageable.getPageSize());
+
         Page<GrowthTrackSnapshot> pageData = growthTrackSnapshotRepository.findAllWithCapsuleMappings(pageable);
-        Page<GrowthTrackResponseDto> dtoPage = pageData.map(growthTrackMapper::toResponseDtoWithCapsules);
+        Page<GrowthTrackResponseDto> dtoPage = pageData.map(entity -> {
+            GrowthTrackResponseDto dto = growthTrackMapper.toResponseDtoWithCapsules(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -297,9 +311,15 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
     @Transactional(readOnly = true)
     @Cacheable(value = "growth-tracks-search", key = "#trackName + '-' + #pageable.pageNumber + '-' + #pageable.pageSize")
     public PaginatedResponseDto<GrowthTrackResponseDto> searchByTrackNameBasic(String trackName, Pageable pageable) {
-        log.debug("Searching growth tracks by name: '{}', page: {}, size: {}", trackName, pageable.getPageNumber(), pageable.getPageSize());
+        log.debug("Searching growth tracks (basic) by name '{}': page={}, size={}",
+                trackName, pageable.getPageNumber(), pageable.getPageSize());
+
         Page<GrowthTrackSnapshot> pageData = growthTrackSnapshotRepository.findByTrackNameContainingIgnoreCase(trackName, pageable);
-        Page<GrowthTrackResponseDto> dtoPage = pageData.map(growthTrackMapper::toBasicResponseDto);
+        Page<GrowthTrackResponseDto> dtoPage = pageData.map(entity -> {
+            GrowthTrackResponseDto dto = growthTrackMapper.toBasicResponseDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -307,18 +327,29 @@ public class GrowthTrackSnapshotServiceImpl implements GrowthTrackSnapshotServic
     @Transactional(readOnly = true)
     @Cacheable(value = "growth-track-single", key = "#growthTrackId")
     public Optional<GrowthTrackResponseDto> findByGrowthTrackIdBasic(UUID growthTrackId) {
-        log.debug("Finding growth track by ID with basic info: {}", growthTrackId);
+        log.debug("Finding growth track (basic) by growthTrackId: {}", growthTrackId);
+
         return growthTrackSnapshotRepository.findByGrowthTrackId(growthTrackId)
-                .map(growthTrackMapper::toBasicResponseDto);
+                .map(entity -> {
+                    GrowthTrackResponseDto dto = growthTrackMapper.toBasicResponseDto(entity);
+                    dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+                    return dto;
+                });
     }
+
 
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = "growth-track-single", key = "#growthTrackId + '-with-capsules'")
     public Optional<GrowthTrackResponseDto> findByGrowthTrackIdWithCapsuleSummaries(UUID growthTrackId) {
-        log.debug("Finding growth track by ID with capsule summaries: {}", growthTrackId);
+        log.debug("Finding growth track with capsule summaries by growthTrackId: {}", growthTrackId);
+
         return growthTrackSnapshotRepository.findByGrowthTrackIdWithCapsuleMappings(growthTrackId)
-                .map(growthTrackMapper::toResponseDtoWithCapsules);
+                .map(entity -> {
+                    GrowthTrackResponseDto dto = growthTrackMapper.toResponseDtoWithCapsules(entity);
+                    dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+                    return dto;
+                });
     }
 
     // Helper classes

--- a/src/main/java/com/capstone/service/impl/S3ImageServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/S3ImageServiceImpl.java
@@ -1,0 +1,49 @@
+package com.capstone.service.impl;
+
+import com.capstone.service.S3ImageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3ImageServiceImpl implements S3ImageService {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${AWS_BUCKET_NAME}")
+    private String bucketName;
+
+    @Value("${AWS_PRESIGNED_URL_EXPIRATION:3600}")
+    private long urlExpiration;
+
+    @Override
+    public String generatePresignedUrl(String imageKey) {
+        if (imageKey == null || imageKey.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofSeconds(urlExpiration))
+                    .getObjectRequest(req -> req
+                            .bucket(bucketName)
+                            .key(imageKey))
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+            return presignedRequest.url().toString();
+
+        } catch (Exception e) {
+            log.error("Error generating presigned URL for image key: {}", imageKey, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/TalentRouteSnapshotServiceImpl.java
@@ -10,6 +10,7 @@ import com.capstone.model.RouteTrackMapping;
 import com.capstone.model.TalentRouteSnapshot;
 import com.capstone.repository.TalentRouteSnapshotRepository;
 import com.capstone.service.GrowthTrackSnapshotService;
+import com.capstone.service.S3ImageService;
 import com.capstone.service.TalentRouteSnapshotService;
 import com.capstone.util.PaginationUtil;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
     private final TalentRouteEventMapper talentRouteEventMapper;
     private final TalentRouteMapper talentRouteMapper;
     private final GrowthTrackSnapshotService growthTrackSnapshotService;
+    private final S3ImageService s3ImageService;
 
     @Override
     @CacheEvict(value = {
@@ -284,7 +286,11 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
             pageable.getPageNumber(), pageable.getPageSize());
 
         Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findAll(pageable);
-        Page<TalentRouteResponseDto> dtoPage = pageData.map(talentRouteMapper::toBasicResponseDto);
+        Page<TalentRouteResponseDto> dtoPage = pageData.map(entity -> {
+            TalentRouteResponseDto dto = talentRouteMapper.toBasicResponseDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -296,7 +302,18 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
             pageable.getPageNumber(), pageable.getPageSize());
 
         Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findAllWithTrackMappings(pageable);
-        Page<TalentRouteResponseDto> dtoPage = pageData.map(talentRouteMapper::toResponseDtoWithTracks);
+        Page<TalentRouteResponseDto> dtoPage = pageData.map(entity -> {
+            TalentRouteResponseDto dto = talentRouteMapper.toResponseDtoWithTracks(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+
+            // Also generate presigned URLs for growth track images in the tracks list
+            if (dto.getTracks() != null) {
+                dto.getTracks().forEach(track ->
+                        track.setImage(s3ImageService.generatePresignedUrl(track.getImage()))
+                );
+            }
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -308,7 +325,11 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
             routeName, pageable.getPageNumber(), pageable.getPageSize());
 
         Page<TalentRouteSnapshot> pageData = talentRouteSnapshotRepository.findByRouteNameContainingIgnoreCase(routeName, pageable);
-        Page<TalentRouteResponseDto> dtoPage = pageData.map(talentRouteMapper::toBasicResponseDto);
+        Page<TalentRouteResponseDto> dtoPage = pageData.map(entity -> {
+            TalentRouteResponseDto dto = talentRouteMapper.toBasicResponseDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -319,7 +340,11 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
         log.debug("Finding talent route (basic) by talentRouteId: {}", talentRouteId);
 
         return talentRouteSnapshotRepository.findByTalentRouteId(talentRouteId)
-                .map(talentRouteMapper::toBasicResponseDto);
+                .map(entity -> {
+                    TalentRouteResponseDto dto = talentRouteMapper.toBasicResponseDto(entity);
+                    dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+                    return dto;
+                });
     }
 
     @Override
@@ -329,7 +354,18 @@ public class TalentRouteSnapshotServiceImpl implements TalentRouteSnapshotServic
         log.debug("Finding talent route with track summaries by talentRouteId: {}", talentRouteId);
 
         return talentRouteSnapshotRepository.findByTalentRouteIdWithTrackMappings(talentRouteId)
-                .map(talentRouteMapper::toResponseDtoWithTracks);
+                .map(entity -> {
+                    TalentRouteResponseDto dto = talentRouteMapper.toResponseDtoWithTracks(entity);
+                    dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+
+                    // Also generate presigned URLs for growth track images in the tracks list
+                    if (dto.getTracks() != null) {
+                        dto.getTracks().forEach(track ->
+                                track.setImage(s3ImageService.generatePresignedUrl(track.getImage()))
+                        );
+                    }
+                    return dto;
+                });
     }
 
     // Helper classes


### PR DESCRIPTION
# 🚀 Pull Request: Add Image Support with S3 Presigned URLs for TalentRoute and GrowthTrack

## ✅  Summary
Added comprehensive image support for TalentRoute and GrowthTrack entities with AWS S3 integration, enabling the system to store S3 object keys from Kafka events and generate presigned URLs for secure image access.

## 📌  Features Implemented
- [x] Image Field Integration
- [x] AWS S3 Integration
- [x] Service Layer Enhancement
- [x] API Response Enhancement