### PR TITLE
Fix: Add User Profile Picture in Roadmap Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.common</groupId>
             <artifactId>versapath-events</artifactId>
-            <version>3.1.3</version>
+            <version>3.1.6</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/capstone/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/roadmap/recalculate-progress").hasRole("ADMIN")
 
                 // Learner endpoints (learner view) + Mentor
-                .requestMatchers("/api/v1/learner/**").hasAnyRole("LEARNER", "MENTOR")
+                .requestMatchers("/api/v1/learner/**").hasAnyRole("LEARNER", "MENTOR", "ADMIN")
                 .requestMatchers(HttpMethod.POST,"/api/v1/roadmap/learner-onboarding").hasRole("LEARNER")
 
                 // Any other request requires authentication

--- a/src/main/java/com/capstone/dto/response/LearnerDto.java
+++ b/src/main/java/com/capstone/dto/response/LearnerDto.java
@@ -16,4 +16,5 @@ public class LearnerDto {
     private String email;
     private String firstName;
     private String lastName;
+    private String image;
 }

--- a/src/main/java/com/capstone/dto/response/MentorResponseDto.java
+++ b/src/main/java/com/capstone/dto/response/MentorResponseDto.java
@@ -22,5 +22,6 @@ public class MentorResponseDto {
     private String firstName;
     private String lastName;
     private Integer totalAssignedLearners;
+    private String image;
     private List<MentorSpecializationDto> specializations;
 }

--- a/src/main/java/com/capstone/mapper/MentorEventMapper.java
+++ b/src/main/java/com/capstone/mapper/MentorEventMapper.java
@@ -10,6 +10,7 @@ import org.mapstruct.MappingTarget;
 public interface MentorEventMapper {
 
     @Mapping(source = "versapathUserId", target = "mentorId")
+    @Mapping(source = "imageUrl", target = "image")
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "assignedLearner", constant = "0")
     @Mapping(target = "createdAt", ignore = true)
@@ -18,6 +19,7 @@ public interface MentorEventMapper {
     MentorSnapshot toMentorSnapshot(ProduceMentorEvent event);
 
     @Mapping(target = "mentorId", ignore = true)
+    @Mapping(source = "imageUrl", target = "image")
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "assignedLearner", ignore = true)
     @Mapping(target = "createdAt", ignore = true)

--- a/src/main/java/com/capstone/mapper/MentorMapper.java
+++ b/src/main/java/com/capstone/mapper/MentorMapper.java
@@ -7,19 +7,20 @@ import com.capstone.model.MentorRouteMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface MentorMapper {
 
     @Mapping(source = "mentorId", target = "mentorId")
     @Mapping(source = "id", target = "id")
+    @Mapping(source = "image", target = "image")
     @Mapping(source = "assignedLearner", target = "totalAssignedLearners")
     @Mapping(target = "specializations", ignore = true)
     MentorResponseDto toBasicResponseDto(MentorSnapshot mentorSnapshot);
 
     @Mapping(source = "mentorId", target = "mentorId")
     @Mapping(source = "id", target = "id")
+    @Mapping(source = "image", target = "image")
     @Mapping(source = "assignedLearner", target = "totalAssignedLearners")
     @Mapping(source = "mentorRouteMappings", target = "specializations")
     MentorResponseDto toResponseDtoWithSpecializations(MentorSnapshot mentorSnapshot);

--- a/src/main/java/com/capstone/mapper/UserEventMapper.java
+++ b/src/main/java/com/capstone/mapper/UserEventMapper.java
@@ -10,12 +10,14 @@ import org.mapstruct.MappingTarget;
 public interface UserEventMapper {
 
     @Mapping(source = "versapathUserId", target = "userId")
+    @Mapping(source = "imageUrl", target = "image")
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     UserSnapshot toUserSnapshot(ProduceUserEvent event);
 
     @Mapping(target = "userId", ignore = true)
+    @Mapping(source = "imageUrl", target = "image")
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)

--- a/src/main/java/com/capstone/model/MentorSnapshot.java
+++ b/src/main/java/com/capstone/model/MentorSnapshot.java
@@ -55,6 +55,9 @@ public class MentorSnapshot {
     @Column(name = "assigned_learner", nullable = false)
     private Integer assignedLearner = 0;
 
+    @Column(name = "image", columnDefinition = "TEXT")
+    private String image;
+
     @OneToMany(mappedBy = "mentorSnapshot", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @Builder.Default
     private List<MentorRouteMapping> mentorRouteMappings = new ArrayList<>();

--- a/src/main/java/com/capstone/model/UserSnapshot.java
+++ b/src/main/java/com/capstone/model/UserSnapshot.java
@@ -48,6 +48,9 @@ public class UserSnapshot {
     @Column(name = "last_name", nullable = false)
     private String lastName;
 
+    @Column(name = "image", columnDefinition = "TEXT")
+    private String image;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/capstone/service/impl/MentorSnapshotServiceImpl.java
+++ b/src/main/java/com/capstone/service/impl/MentorSnapshotServiceImpl.java
@@ -3,6 +3,7 @@ package com.capstone.service.impl;
 import com.capstone.dto.response.LearnerDto;
 import com.capstone.dto.response.PaginatedResponseDto;
 import com.capstone.dto.response.MentorResponseDto;
+import com.capstone.dto.response.TalentRouteResponseDto;
 import com.capstone.exception.*;
 import com.capstone.mapper.MentorEventMapper;
 import com.capstone.mapper.MentorMapper;
@@ -14,6 +15,7 @@ import com.capstone.model.UserSnapshot;
 import com.capstone.repository.MentorLearnerMappingRepository;
 import com.capstone.repository.MentorSnapshotRepository;
 import com.capstone.service.MentorSnapshotService;
+import com.capstone.service.S3ImageService;
 import com.capstone.service.TalentRouteSnapshotService;
 import com.capstone.util.PaginationUtil;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,7 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
     private final TalentRouteSnapshotService talentRouteSnapshotService;
     private final MentorLearnerMappingRepository mentorLearnerMappingRepository;
     private final UserMapper userMapper;
+    private final S3ImageService s3ImageService;
 
     @Override
     @CacheEvict(value = {
@@ -269,7 +272,11 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
                 pageable.getPageNumber(), pageable.getPageSize());
 
         Page<MentorSnapshot> pageData = mentorSnapshotRepository.findAll(pageable);
-        Page<MentorResponseDto> dtoPage = pageData.map(mentorMapper::toBasicResponseDto);
+        Page<MentorResponseDto> dtoPage = pageData.map(entity -> {
+            MentorResponseDto dto = mentorMapper.toBasicResponseDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -281,7 +288,11 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
                 pageable.getPageNumber(), pageable.getPageSize());
 
         Page<MentorSnapshot> pageData = mentorSnapshotRepository.findAllWithRouteMappings(pageable);
-        Page<MentorResponseDto> dtoPage = pageData.map(mentorMapper::toResponseDtoWithSpecializations);
+        Page<MentorResponseDto> dtoPage = pageData.map(entity -> {
+            MentorResponseDto dto = mentorMapper.toResponseDtoWithSpecializations(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -293,7 +304,11 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
                 name, pageable.getPageNumber(), pageable.getPageSize());
 
         Page<MentorSnapshot> pageData = mentorSnapshotRepository.findByNameContainingIgnoreCase(name, pageable);
-        Page<MentorResponseDto> dtoPage = pageData.map(mentorMapper::toBasicResponseDto);
+        Page<MentorResponseDto> dtoPage = pageData.map(entity -> {
+            MentorResponseDto dto = mentorMapper.toBasicResponseDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -304,7 +319,11 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
         log.debug("Finding mentor by ID (basic): {}", mentorId);
 
         return mentorSnapshotRepository.findByMentorId(mentorId)
-                .map(mentorMapper::toBasicResponseDto);
+            .map(entity -> {
+                MentorResponseDto dto = mentorMapper.toBasicResponseDto(entity);
+                dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+                return dto;
+            });
     }
 
     @Override
@@ -313,8 +332,12 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
     public Optional<MentorResponseDto> findByMentorIdWithSpecializations(UUID mentorId) {
         log.debug("Finding mentor by ID with specializations: {}", mentorId);
 
-        return mentorSnapshotRepository.findByMentorIdWithRouteMappings(mentorId)
-                .map(mentorMapper::toResponseDtoWithSpecializations);
+        return mentorSnapshotRepository.findByMentorId(mentorId)
+                .map(entity -> {
+                    MentorResponseDto dto = mentorMapper.toResponseDtoWithSpecializations(entity);
+                    dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+                    return dto;
+                });
     }
 
     @Override
@@ -325,7 +348,11 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
                 talentRouteId, pageable.getPageNumber(), pageable.getPageSize());
 
         Page<MentorSnapshot> pageData = mentorSnapshotRepository.findBySpecializationTalentRouteId(talentRouteId, pageable);
-        Page<MentorResponseDto> dtoPage = pageData.map(mentorMapper::toBasicResponseDto);
+        Page<MentorResponseDto> dtoPage = pageData.map(entity -> {
+            MentorResponseDto dto = mentorMapper.toBasicResponseDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
     }
 
@@ -335,7 +362,11 @@ public class MentorSnapshotServiceImpl implements MentorSnapshotService {
                 .orElseThrow( () -> new MentorNotFoundException("A mentor provided doesn't exist")
                 );
         Page<UserSnapshot> pageData = mentorLearnerMappingRepository.findLearnersByMentorId(mentor.getMentorId(), pageable);
-        Page<LearnerDto> dtoPage = pageData.map(userMapper::toDto);
+        Page<LearnerDto> dtoPage = pageData.map(entity -> {
+            LearnerDto dto = userMapper.toDto(entity);
+            dto.setImage(s3ImageService.generatePresignedUrl(entity.getImage()));
+            return dto;
+        });
         return PaginationUtil.toPaginatedResponse(dtoPage);
 
     }


### PR DESCRIPTION
# 🚀 Pull Request: Receive User Profile Picture From UserManagement Service

## ✅  Summary
This PR provides the  functionality of receiving a user event from `usermanagement-service` including the profile-picture url both `learner` and `mentor` and persisting it in the database.

## 📌  Features Add
- [x] Updated respective Dto to include the image attribute
- [x] Updated event mapper class to map the `imageUrl` properly to the `image` field in the database 
- [x] Updated service logic class to retrieve and display the profile picture for both the `learner` and `mentor` 